### PR TITLE
Fix Take Profit price display and rename to Est. Profit

### DIFF
--- a/app.js
+++ b/app.js
@@ -553,15 +553,17 @@ function updateUI(r, capital) {
   el('param-maxloss').textContent    = showTrade ? fmtUSD(r.maxLoss)             : '—';
 
   // Take Profit
-  el('param-tp').textContent         = showTrade ? '$' + fmt(r.takeProfit)        : '—';
-  el('param-tp-pct').textContent     = showTrade
-    ? `+${(r.tpPct * 100).toFixed(0)}% desde entrada (2:1 R/R)`
+  const tpPrice = (r.takeProfit && !isNaN(r.takeProfit)) ? r.takeProfit : null;
+  el('param-tp').textContent     = (showTrade && tpPrice) ? '$' + fmt(tpPrice) : '—';
+  el('param-tp-pct').textContent = (showTrade && tpPrice)
+    ? `${(r.tpPct * 100).toFixed(0)}% move from entry (2:1 R/R)`
     : '';
 
   // Estimated Profit
-  el('param-profit').textContent     = showTrade ? fmtUSD(r.estimatedProfit)      : '—';
-  el('param-profit-detail').textContent = showTrade
-    ? `$${fmt(r.tradeSize)} × ${r.leverage}x × ${(r.tpPct * 100).toFixed(0)}%`
+  const estProfit = (r.estimatedProfit && !isNaN(r.estimatedProfit)) ? r.estimatedProfit : null;
+  el('param-profit').textContent        = (showTrade && estProfit) ? fmtUSD(estProfit) : '—';
+  el('param-profit-detail').textContent = (showTrade && estProfit)
+    ? `$${fmt(r.tradeSize)} × ${r.leverage}x lev × ${(r.tpPct * 100).toFixed(0)}%`
     : '';
 
   // Conditions

--- a/index.html
+++ b/index.html
@@ -93,12 +93,12 @@
             <div class="param-value danger" id="param-maxloss">—</div>
           </div>
           <div class="param-card">
-            <div class="param-label">Take Profit (+14%)</div>
+            <div class="param-label">Take Profit</div>
             <div class="param-value success" id="param-tp">—</div>
             <div class="param-sublabel" id="param-tp-pct"></div>
           </div>
           <div class="param-card profit-card">
-            <div class="param-label">Ganancia Estimada</div>
+            <div class="param-label">Est. Profit</div>
             <div class="param-value profit" id="param-profit">—</div>
             <div class="param-sublabel" id="param-profit-detail"></div>
           </div>
@@ -184,6 +184,6 @@
 
   </div>
 
-  <script src="app.js"></script>
+  <script src="app.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
- Take Profit now shows the target price ($XX,XXX) with % as subtitle
- Renamed 'Ganancia Estimada' to 'Est. Profit' (English)
- Added cache-busting to script tag so browser loads fresh JS
- Made profit/TP value checks more defensive to avoid showing dashes

https://claude.ai/code/session_01PhvmBgN6iWHfRUFn7cJ3xA