### PR TITLE
fix: redesign TF selector as segmented control; move history to tab nav

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ function getApiUrls(tf) {
   };
 }
 
-let currentTimeframe = '1h';
+let currentTimeframe = '4h';
 
 let refreshTimer = null;
 let countdownInterval = null;
@@ -873,18 +873,24 @@ function exportTradeHistory() {
 
 function renderTradeHistory() {
   const history = getTradeHistory();
-  const section = el('history-section');
   const list    = el('history-list');
   const countEl = el('history-count');
-  if (!section) return;
+  const badge   = el('history-tab-badge');
+  if (!list) return;
+
+  // Update tab badge
+  if (badge) {
+    badge.textContent    = history.length;
+    badge.style.display  = history.length ? '' : 'none';
+  }
+  if (countEl) countEl.textContent = `${history.length} trade${history.length !== 1 ? 's' : ''}`;
+
+  list.innerHTML = '';
 
   if (history.length === 0) {
-    section.style.display = 'none';
+    list.innerHTML = '<div class="history-empty">No closed trades yet.<br>Enter a trade and close it to see your history here.</div>';
     return;
   }
-
-  section.style.display = 'block';
-  countEl.textContent   = `${history.length} trade${history.length !== 1 ? 's' : ''}`;
 
   // Totals summary
   const wins    = history.filter(t => t.pnl >= 0).length;
@@ -1214,6 +1220,18 @@ function switchTimeframe(tf) {
   clearTimeout(refreshTimer);
   clearInterval(countdownInterval);
   run();
+}
+
+// ============================================================
+// TAB SWITCHING
+// ============================================================
+
+function switchTab(tab) {
+  document.querySelectorAll('.tab-nav-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.tab === tab);
+  });
+  el('panel-dashboard').style.display = tab === 'dashboard' ? '' : 'none';
+  el('panel-history').style.display   = tab === 'history'   ? '' : 'none';
 }
 
 // ============================================================

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
         <div class="header-meta">
           <span class="strategy-tag">Jaime Merino Strategy</span>
           <div class="tf-selector">
-            <button class="tf-btn active" data-tf="1h" onclick="switchTimeframe('1h')">1H</button>
-            <button class="tf-btn" data-tf="4h" onclick="switchTimeframe('4h')">4H</button>
+            <button class="tf-btn" data-tf="1h" onclick="switchTimeframe('1h')">1H</button>
+            <button class="tf-btn active" data-tf="4h" onclick="switchTimeframe('4h')">4H</button>
             <button class="tf-btn" data-tf="1d" onclick="switchTimeframe('1d')">1D</button>
             <button class="tf-btn" data-tf="1w" onclick="switchTimeframe('1w')">1W</button>
           </div>
@@ -32,205 +32,220 @@
       </div>
     </header>
 
-    <main class="main">
+    <!-- TAB NAVIGATION -->
+    <nav class="tab-nav">
+      <button class="tab-nav-btn active" data-tab="dashboard" onclick="switchTab('dashboard')">Dashboard</button>
+      <button class="tab-nav-btn" data-tab="history" onclick="switchTab('history')">
+        History
+        <span class="tab-badge" id="history-tab-badge" style="display:none"></span>
+      </button>
+    </nav>
 
-      <!-- SIGNAL CARD -->
-      <section class="signal-card" id="signal-card">
-        <div class="signal-top">
-          <div class="signal-badge-wrap">
-            <div class="signal-badge" id="signal-badge">
-              <span id="signal-text">LOADING</span>
+    <!-- DASHBOARD PANEL -->
+    <div id="panel-dashboard">
+      <main class="main">
+
+        <!-- SIGNAL CARD -->
+        <section class="signal-card" id="signal-card">
+          <div class="signal-top">
+            <div class="signal-badge-wrap">
+              <div class="signal-badge" id="signal-badge">
+                <span id="signal-text">LOADING</span>
+              </div>
+              <div class="signal-direction" id="signal-direction"></div>
             </div>
-            <div class="signal-direction" id="signal-direction"></div>
-          </div>
-          <div class="signal-strength-block">
-            <div class="strength-label">Confluence</div>
-            <div class="strength-dots" id="strength-dots">
-              <span class="dot" id="dot-1"></span>
-              <span class="dot" id="dot-2"></span>
-              <span class="dot" id="dot-3"></span>
-              <span class="dot" id="dot-4"></span>
-              <span class="dot" id="dot-5"></span>
-            </div>
-            <div class="strength-text" id="strength-text">0 / 5 conditions met</div>
-          </div>
-        </div>
-        <div class="signal-subtitle" id="signal-subtitle">Connecting to Bitfinex market data…</div>
-        <!-- Enter Trade button — visible only when signal is active -->
-        <div class="enter-trade-wrap" id="enter-trade-wrap" style="display:none">
-          <button class="enter-trade-btn" id="enter-trade-btn" onclick="enterTrade()">
-            ⚡ Enter Trade at Market Price
-          </button>
-          <div class="enter-trade-note">Records your entry and starts 30s exit monitoring</div>
-        </div>
-      </section>
-
-      <!-- ACTIVE TRADE MONITOR — shown only when a trade is open -->
-      <section class="trade-monitor" id="trade-monitor" style="display:none">
-        <div class="monitor-header">
-          <div class="monitor-left">
-            <span class="monitor-badge" id="monitor-badge">LONG ACTIVE</span>
-            <span class="monitor-since" id="monitor-since"></span>
-          </div>
-          <button class="close-trade-btn" onclick="closeTrade()">✕ Close Trade</button>
-        </div>
-
-        <!-- P&L -->
-        <div class="monitor-pnl-row">
-          <div class="monitor-pnl-block">
-            <div class="monitor-pnl-label">Unrealized P&amp;L</div>
-            <div class="monitor-pnl-value" id="monitor-pnl">—</div>
-            <div class="monitor-pnl-pct" id="monitor-pnl-pct">—</div>
-          </div>
-          <div class="monitor-entry-block">
-            <div class="monitor-entry-row"><span>Entry</span><strong id="monitor-entry-price">—</strong></div>
-            <div class="monitor-entry-row"><span>Current</span><strong id="monitor-current-price">—</strong></div>
-            <div class="monitor-entry-row"><span>Stop Loss</span><strong id="monitor-sl">—</strong></div>
-            <div class="monitor-entry-row"><span>Leverage</span><strong id="monitor-lev">—</strong></div>
-          </div>
-        </div>
-
-        <!-- Exit Signal Status -->
-        <div class="exit-status-bar" id="exit-status-bar">
-          <div class="exit-status-dot" id="exit-status-dot"></div>
-          <div class="exit-status-text" id="exit-status-text">Analyzing…</div>
-        </div>
-
-        <!-- Exit Tips -->
-        <div class="exit-tips-list" id="exit-tips-list"></div>
-
-        <div class="monitor-footer">
-          <span>🔄 Monitoring every 30s · Last check: <strong id="monitor-last-check">—</strong></span>
-        </div>
-      </section>
-
-      <!-- CAPITAL INPUT + TRADE PARAMS -->
-      <section class="trade-section">
-        <div class="capital-row">
-          <div class="capital-block">
-            <label class="field-label" for="capital-input">Your Capital (USD)</label>
-            <div class="capital-input-wrap">
-              <span class="currency-symbol">$</span>
-              <input
-                type="number"
-                id="capital-input"
-                class="capital-input"
-                value="5000"
-                min="1"
-                step="100"
-                placeholder="5000"
-              />
+            <div class="signal-strength-block">
+              <div class="strength-label">Confluence</div>
+              <div class="strength-dots" id="strength-dots">
+                <span class="dot" id="dot-1"></span>
+                <span class="dot" id="dot-2"></span>
+                <span class="dot" id="dot-3"></span>
+                <span class="dot" id="dot-4"></span>
+                <span class="dot" id="dot-5"></span>
+              </div>
+              <div class="strength-text" id="strength-text">0 / 5 conditions met</div>
             </div>
           </div>
-          <div class="capital-note">10% of capital per trade</div>
-        </div>
+          <div class="signal-subtitle" id="signal-subtitle">Connecting to Bitfinex market data…</div>
+          <!-- Enter Trade button — visible only when signal is active -->
+          <div class="enter-trade-wrap" id="enter-trade-wrap" style="display:none">
+            <button class="enter-trade-btn" id="enter-trade-btn" onclick="enterTrade()">
+              ⚡ Enter Trade at Market Price
+            </button>
+            <div class="enter-trade-note">Records your entry and starts 30s exit monitoring</div>
+          </div>
+        </section>
 
-        <div class="params-grid" id="params-grid">
-          <div class="param-card">
-            <div class="param-label">Trade Size</div>
-            <div class="param-value" id="param-trade-size">—</div>
+        <!-- ACTIVE TRADE MONITOR — shown only when a trade is open -->
+        <section class="trade-monitor" id="trade-monitor" style="display:none">
+          <div class="monitor-header">
+            <div class="monitor-left">
+              <span class="monitor-badge" id="monitor-badge">LONG ACTIVE</span>
+              <span class="monitor-since" id="monitor-since"></span>
+            </div>
+            <button class="close-trade-btn" onclick="closeTrade()">✕ Close Trade</button>
           </div>
-          <div class="param-card">
-            <div class="param-label">Leverage</div>
-            <div class="param-value accent" id="param-leverage">—</div>
-          </div>
-          <div class="param-card">
-            <div class="param-label">Entry Price</div>
-            <div class="param-value" id="param-entry">—</div>
-          </div>
-          <div class="param-card">
-            <div class="param-label">Stop Loss (−7%)</div>
-            <div class="param-value danger" id="param-stoploss">—</div>
-          </div>
-          <div class="param-card">
-            <div class="param-label">Max Loss</div>
-            <div class="param-value danger" id="param-maxloss">—</div>
-          </div>
-          <div class="param-card">
-            <div class="param-label">Take Profit</div>
-            <div class="param-value success" id="param-tp">—</div>
-            <div class="param-sublabel" id="param-tp-pct"></div>
-          </div>
-          <div class="param-card profit-card">
-            <div class="param-label">Est. Profit</div>
-            <div class="param-value profit" id="param-profit">—</div>
-            <div class="param-sublabel" id="param-profit-detail"></div>
-          </div>
-        </div>
-      </section>
 
-      <!-- CONDITIONS -->
-      <section class="conditions-section">
-        <div class="section-header">
-          <h2 class="section-title">Entry Conditions</h2>
-          <span class="conditions-badge" id="conditions-badge">0 / 5</span>
-        </div>
-        <div class="conditions-list" id="conditions-list">
-          <div class="condition-loading">Analyzing…</div>
-        </div>
-      </section>
+          <!-- P&L -->
+          <div class="monitor-pnl-row">
+            <div class="monitor-pnl-block">
+              <div class="monitor-pnl-label">Unrealized P&amp;L</div>
+              <div class="monitor-pnl-value" id="monitor-pnl">—</div>
+              <div class="monitor-pnl-pct" id="monitor-pnl-pct">—</div>
+            </div>
+            <div class="monitor-entry-block">
+              <div class="monitor-entry-row"><span>Entry</span><strong id="monitor-entry-price">—</strong></div>
+              <div class="monitor-entry-row"><span>Current</span><strong id="monitor-current-price">—</strong></div>
+              <div class="monitor-entry-row"><span>Stop Loss</span><strong id="monitor-sl">—</strong></div>
+              <div class="monitor-entry-row"><span>Leverage</span><strong id="monitor-lev">—</strong></div>
+            </div>
+          </div>
 
-      <!-- INDICATOR READINGS -->
-      <section class="indicators-section">
-        <h2 class="section-title">Live Indicator Readings</h2>
-        <div class="indicators-grid" id="indicators-grid">
-          <div class="indicator-card">
-            <div class="ind-name">EMA 10 (Fast)</div>
-            <div class="ind-value" id="ind-ema10">—</div>
+          <!-- Exit Signal Status -->
+          <div class="exit-status-bar" id="exit-status-bar">
+            <div class="exit-status-dot" id="exit-status-dot"></div>
+            <div class="exit-status-text" id="exit-status-text">Analyzing…</div>
           </div>
-          <div class="indicator-card">
-            <div class="ind-name">EMA 55 (Bias)</div>
-            <div class="ind-value" id="ind-ema55">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">EMA 200</div>
-            <div class="ind-value" id="ind-ema200">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">RSI (14)</div>
-            <div class="ind-value" id="ind-rsi">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">ADX (14)</div>
-            <div class="ind-value" id="ind-adx">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">BB Upper</div>
-            <div class="ind-value" id="ind-bb-upper">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">BB Lower</div>
-            <div class="ind-value" id="ind-bb-lower">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">Squeeze</div>
-            <div class="ind-value" id="ind-squeeze">—</div>
-          </div>
-          <div class="indicator-card">
-            <div class="ind-name">Vol POC</div>
-            <div class="ind-value" id="ind-poc">—</div>
-          </div>
-        </div>
-      </section>
 
-      <!-- REFRESH STATUS -->
-      <section class="refresh-section">
-        <div class="refresh-row">
-          <div class="refresh-times">
-            <span>Last update: <strong id="last-update">—</strong></span>
-            <span>Next candle: <strong id="next-candle">—</strong></span>
-          </div>
-          <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()">
-            ↻ Refresh Now
-          </button>
-        </div>
-        <div class="countdown-bar-wrap">
-          <div class="countdown-bar" id="countdown-bar"></div>
-        </div>
-      </section>
+          <!-- Exit Tips -->
+          <div class="exit-tips-list" id="exit-tips-list"></div>
 
-      <!-- TRADE HISTORY -->
-      <section class="history-section" id="history-section" style="display:none">
+          <div class="monitor-footer">
+            <span>🔄 Monitoring every 30s · Last check: <strong id="monitor-last-check">—</strong></span>
+          </div>
+        </section>
+
+        <!-- CAPITAL INPUT + TRADE PARAMS -->
+        <section class="trade-section">
+          <div class="capital-row">
+            <div class="capital-block">
+              <label class="field-label" for="capital-input">Your Capital (USD)</label>
+              <div class="capital-input-wrap">
+                <span class="currency-symbol">$</span>
+                <input
+                  type="number"
+                  id="capital-input"
+                  class="capital-input"
+                  value="5000"
+                  min="1"
+                  step="100"
+                  placeholder="5000"
+                />
+              </div>
+            </div>
+            <div class="capital-note">10% of capital per trade</div>
+          </div>
+
+          <div class="params-grid" id="params-grid">
+            <div class="param-card">
+              <div class="param-label">Trade Size</div>
+              <div class="param-value" id="param-trade-size">—</div>
+            </div>
+            <div class="param-card">
+              <div class="param-label">Leverage</div>
+              <div class="param-value accent" id="param-leverage">—</div>
+            </div>
+            <div class="param-card">
+              <div class="param-label">Entry Price</div>
+              <div class="param-value" id="param-entry">—</div>
+            </div>
+            <div class="param-card">
+              <div class="param-label">Stop Loss (−7%)</div>
+              <div class="param-value danger" id="param-stoploss">—</div>
+            </div>
+            <div class="param-card">
+              <div class="param-label">Max Loss</div>
+              <div class="param-value danger" id="param-maxloss">—</div>
+            </div>
+            <div class="param-card">
+              <div class="param-label">Take Profit</div>
+              <div class="param-value success" id="param-tp">—</div>
+              <div class="param-sublabel" id="param-tp-pct"></div>
+            </div>
+            <div class="param-card profit-card">
+              <div class="param-label">Est. Profit</div>
+              <div class="param-value profit" id="param-profit">—</div>
+              <div class="param-sublabel" id="param-profit-detail"></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- CONDITIONS -->
+        <section class="conditions-section">
+          <div class="section-header">
+            <h2 class="section-title">Entry Conditions</h2>
+            <span class="conditions-badge" id="conditions-badge">0 / 5</span>
+          </div>
+          <div class="conditions-list" id="conditions-list">
+            <div class="condition-loading">Analyzing…</div>
+          </div>
+        </section>
+
+        <!-- INDICATOR READINGS -->
+        <section class="indicators-section">
+          <h2 class="section-title">Live Indicator Readings</h2>
+          <div class="indicators-grid" id="indicators-grid">
+            <div class="indicator-card">
+              <div class="ind-name">EMA 10 (Fast)</div>
+              <div class="ind-value" id="ind-ema10">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">EMA 55 (Bias)</div>
+              <div class="ind-value" id="ind-ema55">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">EMA 200</div>
+              <div class="ind-value" id="ind-ema200">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">RSI (14)</div>
+              <div class="ind-value" id="ind-rsi">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">ADX (14)</div>
+              <div class="ind-value" id="ind-adx">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">BB Upper</div>
+              <div class="ind-value" id="ind-bb-upper">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">BB Lower</div>
+              <div class="ind-value" id="ind-bb-lower">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">Squeeze</div>
+              <div class="ind-value" id="ind-squeeze">—</div>
+            </div>
+            <div class="indicator-card">
+              <div class="ind-name">Vol POC</div>
+              <div class="ind-value" id="ind-poc">—</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- REFRESH STATUS -->
+        <section class="refresh-section">
+          <div class="refresh-row">
+            <div class="refresh-times">
+              <span>Last update: <strong id="last-update">—</strong></span>
+              <span>Next candle: <strong id="next-candle">—</strong></span>
+            </div>
+            <button class="refresh-btn" id="refresh-btn" onclick="manualRefresh()">
+              ↻ Refresh Now
+            </button>
+          </div>
+          <div class="countdown-bar-wrap">
+            <div class="countdown-bar" id="countdown-bar"></div>
+          </div>
+        </section>
+
+      </main>
+    </div>
+
+    <!-- HISTORY PANEL -->
+    <div id="panel-history" style="display:none">
+      <section class="history-section" id="history-section">
         <div class="section-header">
           <h2 class="section-title">Trade History</h2>
           <div class="history-header-right">
@@ -241,8 +256,7 @@
         </div>
         <div class="history-list" id="history-list"></div>
       </section>
-
-    </main>
+    </div>
 
     <footer class="footer">
       <div class="footer-disclaimer">
@@ -254,6 +268,6 @@
 
   </div>
 
-  <script src="app.js?v=7"></script>
+  <script src="app.js?v=8"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -75,7 +75,7 @@ html, body {
   justify-content: space-between;
   padding: 20px 0 16px;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 8px;
+  margin-bottom: 0;
 }
 
 .header-left {
@@ -109,26 +109,77 @@ html, body {
   gap: 6px;
 }
 
+/* Segmented control — single connected pill */
 .tf-selector {
   display: flex;
-  gap: 3px;
-}
-
-.tf-btn {
+  align-items: center;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
+  padding: 2px;
+  gap: 1px;
+}
+
+.tf-btn {
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 700;
-  padding: 3px 9px;
+  padding: 4px 11px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background 0.15s, color 0.15s;
   letter-spacing: 0.5px;
+  line-height: 1;
 }
-.tf-btn:hover    { border-color: var(--accent); color: var(--accent); }
-.tf-btn.active   { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
+.tf-btn:hover:not(.active):not(:disabled) { color: var(--text-secondary); }
+.tf-btn.active   { background: var(--bg-card); color: var(--accent); }
 .tf-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* ============================================================
+   TAB NAVIGATION
+   ============================================================ */
+.tab-nav {
+  display: flex;
+  align-items: flex-end;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 20px;
+  gap: 0;
+}
+
+.tab-nav-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 14px 20px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: color 0.2s, border-bottom-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1;
+}
+.tab-nav-btn:hover { color: var(--text-secondary); }
+.tab-nav-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.tab-badge {
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  background: var(--accent-dim);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 20px;
+  padding: 1px 7px;
+  line-height: 1.6;
+}
 
 .btc-price-block {
   display: flex;
@@ -1005,6 +1056,14 @@ html, body {
   margin-top: 2px;
 }
 
+.history-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  padding: 32px 0;
+  text-align: center;
+  line-height: 1.6;
+}
+
 /* ============================================================
    FOOTER
    ============================================================ */
@@ -1077,4 +1136,5 @@ html, body {
   .history-row-top { flex-direction: column; align-items: flex-start; gap: 6px; }
   .history-pnl-wrap { flex-direction: row; }
   .footer-meta { flex-direction: column; gap: 4px; }
+  .tab-nav-btn { padding: 12px 14px; font-size: 12px; }
 }


### PR DESCRIPTION
- Timeframe selector rebuilt as a connected segmented control: single pill container (bg-input + border), floating active button (bg-card + accent color), no individual borders — uses only existing design tokens
- Default timeframe reverted to 4H
- Added underline-indicator tab navigation (Dashboard / History) between header and main, using existing button typography (13px/600/uppercase) and --accent border-bottom on active tab
- Trade History moved to its own tab panel (#panel-history); no longer buried at the bottom of the scroll — always rendered, never hidden
- Tab badge shows trade count using existing .conditions-badge token pattern
- Empty state shown in History tab when no trades (matches .condition-loading style)
- Header margin-bottom removed; tab nav provides the visual separation

https://claude.ai/code/session_01PhvmBgN6iWHfRUFn7cJ3xA