### PR TITLE
fix: dynamic build timestamp, human-readable countdown, local TZ display

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,9 +3,16 @@
 // BTC/USD · Bitfinex
 // ============================================================
 
-const APP_VERSION    = 'v1.2.0';
-const DEPLOY_DATE    = '2026-03-13';
-const DEPLOY_TIME    = '08:51 UTC';
+const APP_VERSION = 'v1.2.0';
+
+// User's local timezone abbreviation (e.g. "CET", "EST", "GMT+5")
+const USER_TZ_ABBR = (() => {
+  try {
+    return new Intl.DateTimeFormat('en', { timeZoneName: 'short' })
+      .formatToParts(new Date())
+      .find(p => p.type === 'timeZoneName')?.value ?? '';
+  } catch { return ''; }
+})();
 
 // Timeframe → API interval mapping
 function getApiUrls(tf) {
@@ -1139,7 +1146,8 @@ function updateUI(r, capital) {
   }
 
   // Time
-  el('last-update').textContent = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  el('last-update').textContent = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    + (USER_TZ_ABBR ? '\u00a0' + USER_TZ_ABBR : '');
 }
 
 // ============================================================
@@ -1177,6 +1185,18 @@ function msUntilNextCandle() {
   return { ms: next - now, date: next };
 }
 
+function fmtCountdown(remainingMs) {
+  const totalSec = Math.floor(remainingMs / 1000);
+  const sec  = totalSec % 60;
+  const min  = Math.floor(totalSec / 60) % 60;
+  const hrs  = Math.floor(totalSec / 3600) % 24;
+  const days = Math.floor(totalSec / 86400);
+  if (currentTimeframe === '1w') return `${days}d ${hrs}h`;
+  if (currentTimeframe === '1d') return `${hrs}h ${min}m`;
+  if (currentTimeframe === '4h') return `${Math.floor(totalSec / 3600)}h ${min}m`;
+  return `${Math.floor(totalSec / 60)}m ${sec}s`; // 1h
+}
+
 function startCountdown() {
   clearInterval(countdownInterval);
   const bar    = el('countdown-bar');
@@ -1194,10 +1214,7 @@ function startCountdown() {
     const pct = (remaining / totalMs) * 100;
     bar.style.width = pct + '%';
 
-    // Format countdown
-    const m = Math.floor(remaining / 60000);
-    const s = Math.floor((remaining % 60000) / 1000);
-    nextEl.textContent = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    nextEl.textContent = fmtCountdown(remaining);
   }, 1000);
 }
 
@@ -1295,12 +1312,30 @@ el('capital-input').addEventListener('change', () => {
 // BOOT
 // ============================================================
 
-// Version + deploy info in footer
+// Version + deploy info in footer — loaded from version.json (stamped by build.js)
 const _footerMeta = el('footer-meta');
-if (_footerMeta) _footerMeta.innerHTML =
-  `<span class="footer-version">${APP_VERSION}</span>` +
-  `<span class="footer-sep">·</span>` +
-  `<span>Last deploy: ${DEPLOY_DATE} ${DEPLOY_TIME}</span>`;
+if (_footerMeta) {
+  _footerMeta.innerHTML =
+    `<span class="footer-version">${APP_VERSION}</span>`;
+
+  fetch('version.json?_=' + Date.now())
+    .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+    .then(v => {
+      if (!v.buildDate) return;
+      const d       = new Date(v.buildDate);
+      const dateStr = d.toLocaleDateString('en-CA');          // YYYY-MM-DD
+      const timeStr = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const tz      = USER_TZ_ABBR ? '\u00a0' + USER_TZ_ABBR : '';
+      _footerMeta.innerHTML =
+        `<span class="footer-version">v${v.version}</span>` +
+        `<span class="footer-sep">·</span>` +
+        `<span>Last deploy: ${dateStr}\u00a0${timeStr}${tz}</span>`;
+    })
+    .catch(() => {
+      // Fetch unavailable (e.g. file:// protocol) — show version only
+      _footerMeta.innerHTML = `<span class="footer-version">${APP_VERSION}</span>`;
+    });
+}
 
 // Init timeframe button states
 document.querySelectorAll('.tf-btn').forEach(b => {

--- a/build.js
+++ b/build.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Stamps the current UTC timestamp into version.json before deploy.
+// Run: node build.js  (or: npm run build)
+
+const fs   = require('fs');
+const path = require('path');
+
+const versionFile = path.join(__dirname, 'version.json');
+const v = JSON.parse(fs.readFileSync(versionFile, 'utf8'));
+
+v.buildDate = new Date().toISOString();
+
+fs.writeFileSync(versionFile, JSON.stringify(v, null, 2) + '\n');
+console.log(`[build] Timestamp set → ${v.buildDate}`);

--- a/index.html
+++ b/index.html
@@ -268,6 +268,6 @@
 
   </div>
 
-  <script src="app.js?v=8"></script>
+  <script src="app.js?v=9"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mycfo",
+  "version": "1.2.0",
+  "description": "BTC/USD Signal Dashboard — Jaime Merino Strategy",
+  "scripts": {
+    "build": "node build.js"
+  }
+}

--- a/version.json
+++ b/version.json
@@ -1,10 +1,22 @@
 {
   "version": "1.2.0",
-  "buildDate": "2026-03-13",
+  "buildDate": "2026-03-13T09:33:05.430Z",
   "buildTime": "08:51 UTC",
   "changelog": [
-    { "version": "1.2.0", "date": "2026-03-13", "notes": "Default timeframe 1H; footer deploy datetime; enriched trade history with asset/ISO timestamps/notes/export-to-JSON; summary stats bar" },
-    { "version": "1.1.0", "date": "2026-03-12", "notes": "Timeframe selector (1H/4H/1D/1W); trade monitor; exit signal analysis; trade history with localStorage" },
-    { "version": "1.0.0", "date": "2026-03-12", "notes": "Initial release — BTC/USD signal dashboard, Jaime Merino strategy" }
+    {
+      "version": "1.2.0",
+      "date": "2026-03-13",
+      "notes": "Default timeframe 1H; footer deploy datetime; enriched trade history with asset/ISO timestamps/notes/export-to-JSON; summary stats bar"
+    },
+    {
+      "version": "1.1.0",
+      "date": "2026-03-12",
+      "notes": "Timeframe selector (1H/4H/1D/1W); trade monitor; exit signal analysis; trade history with localStorage"
+    },
+    {
+      "version": "1.0.0",
+      "date": "2026-03-12",
+      "notes": "Initial release — BTC/USD signal dashboard, Jaime Merino strategy"
+    }
   ]
 }


### PR DESCRIPTION
Deploy timestamp:
- Remove hardcoded DEPLOY_DATE/DEPLOY_TIME from app.js
- Add build.js: stamps current UTC ISO timestamp into version.json
- Add package.json with "build": "node build.js"
- At boot, app fetches version.json and renders deploy time in user's local timezone with TZ abbreviation; falls back to version-only if fetch unavailable (file:// protocol)

Human-readable countdown (Next candle):
- Add fmtCountdown(remainingMs): adapts format to active timeframe 1H → "43m 12s" | 4H → "2h 14m" | 1D → "14h 32m" | 1W → "3d 7h"
- Replace raw MM:SS output in startCountdown() with fmtCountdown()

Timezone:
- Add USER_TZ_ABBR constant: detected once via Intl.DateTimeFormat (e.g. "CET", "EST", "GMT+5") with try/catch fallback to ''
- Last update time now shows: "10:21 CET"
- Deploy footer now shows: "2026-03-13 10:33 CET"

https://claude.ai/code/session_01PhvmBgN6iWHfRUFn7cJ3xA