### PR TITLE
fix: resolve #21 — replace TradingView/AllOrigins with Yahoo Finance …

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // ============================================================
 // myCFO — Jaime Merino Strategy Signal Engine
-// Multi-Asset · Bitfinex / Binance / TradingView UDF
+// Multi-Asset · Bitfinex / Binance / Yahoo Finance Proxy
 // ============================================================
 
 const APP_VERSION = 'v1.4.0';
@@ -31,25 +31,25 @@ const STRATEGY = {
 
 // ── Asset registry ─────────────────────────────────────────
 const ASSETS = {
-  // Futures — Indices (TradingView UDF for data)
-  'ES1!':  { name: 'S&P 500 E-mini',     category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:ES1!' },
-  'NQ1!':  { name: 'Nasdaq 100 E-mini',   category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:NQ1!' },
-  'YM1!':  { name: 'Dow Jones E-mini',    category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CBOT_MINI:YM1!' },
-  'RTY1!': { name: 'Russell 2000 E-mini', category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:RTY1!' },
-  'DAX1!': { name: 'DAX Futures',         category: 'Futures — Indices',      market: 'eurex', bitfinex: null, binance: null, tradingview: 'EUREX:FDAX1!' },
-  'NKD1!': { name: 'Nikkei 225 Futures',  category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME:NKD1!' },
-  // Futures — Commodities (TradingView UDF for data)
-  'GC1!':  { name: 'Gold',                category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:GC1!' },
-  'SI1!':  { name: 'Silver',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:SI1!' },
-  'CL1!':  { name: 'Crude Oil WTI',       category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:CL1!' },
-  'NG1!':  { name: 'Natural Gas',         category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:NG1!' },
-  'HG1!':  { name: 'Copper',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:HG1!' },
-  // FX Pairs (TradingView UDF for data)
-  'GBP/USD': { name: 'British Pound',     category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:GBPUSD' },
-  'EUR/USD': { name: 'Euro',              category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:EURUSD' },
-  'USD/JPY': { name: 'Japanese Yen',      category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDJPY' },
-  'AUD/USD': { name: 'Australian Dollar', category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:AUDUSD' },
-  'USD/CHF': { name: 'Swiss Franc',       category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDCHF' },
+  // Futures — Indices (Yahoo Finance proxy for data)
+  'ES1!':  { name: 'S&P 500 E-mini',     category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:ES1!',  yahoo: 'ES=F' },
+  'NQ1!':  { name: 'Nasdaq 100 E-mini',   category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:NQ1!',  yahoo: 'NQ=F' },
+  'YM1!':  { name: 'Dow Jones E-mini',    category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CBOT_MINI:YM1!', yahoo: 'YM=F' },
+  'RTY1!': { name: 'Russell 2000 E-mini', category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:RTY1!', yahoo: 'RTY=F' },
+  'DAX1!': { name: 'DAX Futures',         category: 'Futures — Indices',      market: 'eurex', bitfinex: null, binance: null, tradingview: 'EUREX:FDAX1!',   yahoo: '^GDAXI' },
+  'NKD1!': { name: 'Nikkei 225 Futures',  category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME:NKD1!',      yahoo: 'NKD=F' },
+  // Futures — Commodities (Yahoo Finance proxy for data)
+  'GC1!':  { name: 'Gold',                category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:GC1!',     yahoo: 'GC=F' },
+  'SI1!':  { name: 'Silver',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:SI1!',     yahoo: 'SI=F' },
+  'CL1!':  { name: 'Crude Oil WTI',       category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:CL1!',     yahoo: 'CL=F' },
+  'NG1!':  { name: 'Natural Gas',         category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:NG1!',     yahoo: 'NG=F' },
+  'HG1!':  { name: 'Copper',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:HG1!',     yahoo: 'HG=F' },
+  // FX Pairs (Yahoo Finance proxy for data)
+  'GBP/USD': { name: 'British Pound',     category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:GBPUSD', yahoo: 'GBPUSD=X' },
+  'EUR/USD': { name: 'Euro',              category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:EURUSD', yahoo: 'EURUSD=X' },
+  'USD/JPY': { name: 'Japanese Yen',      category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDJPY', yahoo: 'JPY=X' },
+  'AUD/USD': { name: 'Australian Dollar', category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:AUDUSD', yahoo: 'AUDUSD=X' },
+  'USD/CHF': { name: 'Swiss Franc',       category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDCHF', yahoo: 'CHF=X' },
   // Crypto (Bitfinex + Binance)
   'BTC/USD': { name: 'Bitcoin',   category: 'Crypto', market: 'crypto', bitfinex: 'tBTCUSD', binance: 'BTCUSDT', tradingview: null },
   'ETH/USD': { name: 'Ethereum',  category: 'Crypto', market: 'crypto', bitfinex: 'tETHUSD', binance: 'ETHUSDT', tradingview: null },
@@ -139,17 +139,13 @@ function getApiUrls(tf, assetKey) {
     };
   }
 
-  // Non-crypto assets (Futures, FX): AllOrigins-proxied TradingView UDF
-  if (asset && asset.tradingview) {
-    const tvTf = { '1h': '60', '4h': '240', '1d': 'D', '1w': 'W' }[tf] || '240';
-    const now = Math.floor(Date.now() / 1000);
-    const secondsPerCandle = { '1h': 3600, '4h': 14400, '1d': 86400, '1w': 604800 }[tf] || 14400;
-    const from = now - secondsPerCandle * STRATEGY.CANDLE_LIMIT;
-    const tvUrl = `https://tvc4.investing.com/57bf5541e6f1767f88541b7b68415f38/0/0/0/0/history?symbol=${encodeURIComponent(asset.tradingview)}&resolution=${tvTf}&from=${from}&to=${now}`;
+  // Non-crypto assets (Futures, FX): server-side Yahoo Finance proxy
+  if (asset && asset.yahoo) {
+    const yahooTf = { '1h': '1h', '4h': '4h', '1d': '1d', '1w': '1wk' }[tf] || '4h';
+    const range   = { '1h': '1mo', '4h': '3mo', '1d': '2y', '1w': '10y' }[tf] || '3mo';
     return {
-      provider: 'tradingview',
-      url: tvUrl,
-      corsProxy: `https://api.allorigins.win/raw?url=${encodeURIComponent(tvUrl)}`,
+      provider: 'yahoo',
+      url: `/api/market-data?symbol=${encodeURIComponent(assetKey || state.currentAsset)}&interval=${yahooTf}&range=${range}`,
     };
   }
 
@@ -1179,7 +1175,7 @@ function renderTradeHistory() {
 }
 
 // ============================================================
-// FETCH CANDLES — Bitfinex/Binance for Crypto, TradingView UDF for Futures/FX
+// FETCH CANDLES — Bitfinex/Binance for Crypto, Yahoo Finance Proxy for Futures/FX
 // ============================================================
 
 async function fetchCandles(tf, assetKey) {
@@ -1190,9 +1186,9 @@ async function fetchCandles(tf, assetKey) {
     throw new Error(`No data provider configured for ${key}.`);
   }
 
-  // TradingView UDF provider (Futures, FX, Stocks)
-  if (urls.provider === 'tradingview') {
-    return await fetchTradingViewCandles(urls, key);
+  // Yahoo Finance proxy provider (Futures, FX, Stocks)
+  if (urls.provider === 'yahoo') {
+    return await fetchYahooCandles(urls, key);
   }
 
   // Crypto provider: Bitfinex primary, Binance fallback
@@ -1229,39 +1225,24 @@ async function fetchCandles(tf, assetKey) {
   }));
 }
 
-async function fetchTradingViewCandles(urls, key) {
-  let res;
-  try {
-    res = await fetch(urls.url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  } catch (directErr) {
-    console.warn('TradingView direct fetch failed, trying CORS proxy:', directErr.message);
-    res = await fetch(urls.corsProxy);
-    if (!res.ok) throw new Error(`TradingView proxy HTTP ${res.status}`);
+async function fetchYahooCandles(urls, key) {
+  const res = await fetch(urls.url);
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => '');
+    throw new Error(`Market data unavailable for ${key} (HTTP ${res.status}). ${errBody || 'Please try again later.'}`);
   }
   const data = await res.json();
 
-  if (data.s !== 'ok' || !data.t || data.t.length === 0) {
-    throw new Error(`No TradingView data for ${key} (status: ${data.s || 'unknown'})`);
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error(`No market data available for ${key}. This instrument may not be supported yet.`);
   }
 
-  if (data.t.length < 50) {
-    throw new Error(`Insufficient TradingView data for ${key} (${data.t.length} candles)`);
+  if (data.length < 50) {
+    throw new Error(`Insufficient market data for ${key} (${data.length} candles). Try a shorter timeframe.`);
   }
 
-  // TradingView UDF format: { t:[timestamps], o:[opens], h:[highs], l:[lows], c:[closes], v:[volumes] }
-  const candles = [];
-  for (let i = 0; i < data.t.length; i++) {
-    candles.push({
-      time:   data.t[i] * 1000,  // convert seconds → milliseconds to match Bitfinex/Binance format
-      open:   data.o[i],
-      high:   data.h[i],
-      low:    data.l[i],
-      close:  data.c[i],
-      volume: data.v ? data.v[i] : 0,
-    });
-  }
-  return candles;
+  // Proxy returns normalized OHLCV: [{ time, open, high, low, close, volume }]
+  return data;
 }
 
 // ============================================================

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "mycfo",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "BTC/USD Signal Dashboard — Jaime Merino Strategy",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "build": "node build.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// ============================================================
+// SqFlow Server — Static file server + Yahoo Finance proxy
+// Resolves CORS issues for non-crypto market data (Issue #21)
+// ============================================================
+
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+
+// ── Symbol mapping: internal keys → Yahoo Finance tickers ────
+const YAHOO_SYMBOLS = {
+  // Futures — Indices
+  'ES1!':  'ES=F',
+  'NQ1!':  'NQ=F',
+  'YM1!':  'YM=F',
+  'RTY1!': 'RTY=F',
+  'DAX1!': '^GDAXI',
+  'NKD1!': 'NKD=F',
+  // Futures — Commodities
+  'GC1!':  'GC=F',
+  'SI1!':  'SI=F',
+  'CL1!':  'CL=F',
+  'NG1!':  'NG=F',
+  'HG1!':  'HG=F',
+  // FX Pairs
+  'GBP/USD': 'GBPUSD=X',
+  'EUR/USD': 'EURUSD=X',
+  'USD/JPY': 'JPY=X',
+  'AUD/USD': 'AUDUSD=X',
+  'USD/CHF': 'CHF=X',
+};
+
+// ── MIME types for static file serving ───────────────────────
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.css':  'text/css',
+  '.js':   'application/javascript',
+  '.json': 'application/json',
+  '.png':  'image/png',
+  '.jpg':  'image/jpeg',
+  '.ico':  'image/x-icon',
+  '.svg':  'image/svg+xml',
+};
+
+// ── Fetch helper (HTTPS GET with redirects) ──────────────────
+function httpsGet(reqUrl) {
+  return new Promise((resolve, reject) => {
+    const get = (targetUrl, redirectCount) => {
+      if (redirectCount > 5) return reject(new Error('Too many redirects'));
+
+      https.get(targetUrl, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; SqFlow/1.0)',
+          'Accept': 'application/json',
+        },
+      }, (res) => {
+        // Follow redirects
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          return get(res.headers.location, redirectCount + 1);
+        }
+
+        let body = '';
+        res.on('data', chunk => { body += chunk; });
+        res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+        res.on('error', reject);
+      }).on('error', reject);
+    };
+
+    get(reqUrl, 0);
+  });
+}
+
+// ── Aggregate hourly candles into 4h candles ─────────────────
+function aggregate4h(candles) {
+  if (!candles.length) return [];
+  const result = [];
+  // Group into blocks of 4
+  for (let i = 0; i < candles.length; i += 4) {
+    const block = candles.slice(i, i + 4);
+    if (block.length === 0) break;
+    result.push({
+      time:   block[0].time,
+      open:   block[0].open,
+      high:   Math.max(...block.map(c => c.high)),
+      low:    Math.min(...block.map(c => c.low)),
+      close:  block[block.length - 1].close,
+      volume: block.reduce((s, c) => s + c.volume, 0),
+    });
+  }
+  return result;
+}
+
+// ── Yahoo Finance proxy handler ──────────────────────────────
+async function handleMarketData(query, res) {
+  const symbol = query.symbol;
+  let interval = query.interval || '4h';
+  const range = query.range || '3mo';
+
+  if (!symbol) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Missing required parameter: symbol' }));
+    return;
+  }
+
+  const yahooSymbol = YAHOO_SYMBOLS[symbol];
+  if (!yahooSymbol) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: `Unsupported symbol: ${symbol}. Available: ${Object.keys(YAHOO_SYMBOLS).join(', ')}` }));
+    return;
+  }
+
+  // Yahoo Finance doesn't support 4h intervals — fetch 1h and aggregate
+  const needs4hAggregation = interval === '4h';
+  const yahooInterval = needs4hAggregation ? '1h' : interval;
+  const yahooRange = needs4hAggregation ? '2y' : range;
+
+  const yahooUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${yahooInterval}&range=${yahooRange}`;
+
+  try {
+    console.log(`[proxy] ${symbol} → ${yahooSymbol} (interval=${yahooInterval}, range=${yahooRange})`);
+    const { statusCode, body } = await httpsGet(yahooUrl);
+
+    if (statusCode !== 200) {
+      console.warn(`[proxy] Yahoo returned HTTP ${statusCode} for ${yahooSymbol}`);
+      res.writeHead(statusCode === 404 ? 404 : 502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        error: `Market data temporarily unavailable for ${symbol}. Yahoo Finance returned HTTP ${statusCode}.`,
+      }));
+      return;
+    }
+
+    const data = JSON.parse(body);
+    const result = data?.chart?.result?.[0];
+
+    if (!result || !result.timestamp || result.timestamp.length === 0) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        error: `No data available for ${symbol}. The instrument may be delisted or not yet trading.`,
+      }));
+      return;
+    }
+
+    const timestamps = result.timestamp;
+    const quote = result.indicators?.quote?.[0];
+
+    if (!quote) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: `Malformed response from Yahoo Finance for ${symbol}.` }));
+      return;
+    }
+
+    // Build normalized OHLCV array, filtering out null entries
+    let candles = [];
+    for (let i = 0; i < timestamps.length; i++) {
+      const o = quote.open?.[i];
+      const h = quote.high?.[i];
+      const l = quote.low?.[i];
+      const c = quote.close?.[i];
+      const v = quote.volume?.[i] ?? 0;
+
+      // Skip candles with null OHLC data (market closed / no trading)
+      if (o == null || h == null || l == null || c == null) continue;
+
+      candles.push({
+        time:   timestamps[i] * 1000, // seconds → milliseconds
+        open:   o,
+        high:   h,
+        low:    l,
+        close:  c,
+        volume: v,
+      });
+    }
+
+    // Aggregate to 4h if needed
+    if (needs4hAggregation) {
+      candles = aggregate4h(candles);
+    }
+
+    console.log(`[proxy] ${symbol}: ${candles.length} candles returned`);
+
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=60',
+    });
+    res.end(JSON.stringify(candles));
+
+  } catch (err) {
+    console.error(`[proxy] Error fetching ${symbol}:`, err.message);
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      error: `Failed to fetch market data for ${symbol}. Please try again later.`,
+    }));
+  }
+}
+
+// ── Static file server ───────────────────────────────────────
+function serveStatic(pathname, res) {
+  // Default to index.html
+  if (pathname === '/') pathname = '/index.html';
+
+  // Security: prevent directory traversal
+  const safePath = path.normalize(pathname).replace(/^(\.\.[/\\])+/, '');
+  const filePath = path.join(__dirname, safePath);
+
+  // Ensure the file is within the project directory
+  if (!filePath.startsWith(__dirname)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
+        res.writeHead(500);
+        res.end('Internal Server Error');
+      }
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+// ── HTTP server ──────────────────────────────────────────────
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  const pathname = parsed.pathname;
+
+  // CORS headers for API routes
+  if (pathname.startsWith('/api/')) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+  }
+
+  // Route: /api/market-data
+  if (pathname === '/api/market-data' && req.method === 'GET') {
+    handleMarketData(parsed.query, res);
+    return;
+  }
+
+  // Everything else: serve static files
+  serveStatic(pathname, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`[sqflow] Server running at http://localhost:${PORT}`);
+  console.log(`[sqflow] Market data proxy: http://localhost:${PORT}/api/market-data?symbol=ES1!&interval=1h&range=1mo`);
+});


### PR DESCRIPTION
…proxy

Closes #21

- Add server.js with /api/market-data proxy endpoint that fetches from Yahoo Finance v8 API, eliminating CORS errors for non-crypto instruments
- Symbol normalization: map internal keys (ES1!, GC1!, EUR/USD, etc.) to Yahoo Finance format (ES=F, GC=F, EURUSD=X, etc.)
- 4h timeframe support via automatic 1h candle aggregation (Yahoo Finance does not natively support 4h intervals)
- Crypto symbols (BTC/USD, ETH/USD, etc.) continue using Bitfinex/Binance directly — no breaking changes to existing crypto data flow
- User-friendly error messages for unavailable instruments or API failures
- Zero API keys required — Yahoo Finance public endpoints only
- Static file serving built into the same server (npm start)

https://claude.ai/code/session_01G26Mqr8ikivSFykizFkVG5