### PR TITLE
fix: remove Apple and Twitter OAuth providers, resolve #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SqFlow is a real-time trading signal engine that implements the **Jaime Merino S
 - **Multi-trade support** — run concurrent positions across different instruments
 
 ### Authentication & Cloud Sync
-- **Firebase Auth** — Google, Apple, and X (Twitter) OAuth + email/password
+- **Firebase Auth** — Google OAuth + email/password
 - **Firestore cloud sync** — active trades and history available across devices
 - **Guest mode** — fully functional without authentication; seamless migration to account on sign-in
 - **Security** — brute-force rate limiting (5 attempts/min), strict password policy, sanitized error messages

--- a/auth.css
+++ b/auth.css
@@ -82,8 +82,6 @@
 }
 
 .auth-google  { border-color: rgba(66, 133, 244, 0.25); }
-.auth-apple   { border-color: var(--border-light); }
-.auth-twitter { border-color: rgba(29, 155, 240, 0.25); }
 
 /* ── Divider ───────────────────────────────────────────────── */
 .auth-divider {

--- a/auth.js
+++ b/auth.js
@@ -2,13 +2,12 @@
 // SqFlow — Authentication Module
 // Firebase Auth + Firestore
 //
-// Supports: Google OAuth, Apple Sign-In, X (Twitter) OAuth,
-//           Email + Password, Guest session
+// Supports: Google OAuth, Email + Password, Guest session
 //
 // SETUP:
 //   1. Go to https://console.firebase.google.com
 //   2. Create a project (or select existing)
-//   3. Enable Authentication providers: Google, Apple, Twitter
+//   3. Enable Authentication providers: Google, Email/Password
 //   4. Enable Firestore Database (start in production mode)
 //   5. Replace the FIREBASE_CONFIG values below with your project credentials
 // ============================================================
@@ -257,24 +256,6 @@ const Auth = (() => {
     catch (e) { throw new Error(_sanitizeError(e.code)); }
   }
 
-  async function signInWithApple() {
-    if (!_auth) throw new Error('Apple sign-in is not yet configured. The Firebase project credentials need to be added to enable this provider.');
-    // Note: Apple Sign-In requires additional setup in Firebase console
-    // and an Apple Developer account with Services ID configuration.
-    const provider = new firebase.auth.OAuthProvider('apple.com');
-    provider.addScope('email');
-    provider.addScope('name');
-    try { return await _auth.signInWithPopup(provider); }
-    catch (e) { throw new Error(_sanitizeError(e.code)); }
-  }
-
-  async function signInWithTwitter() {
-    if (!_auth) throw new Error('X (Twitter) sign-in is not yet configured. The Firebase project credentials need to be added to enable this provider.');
-    const provider = new firebase.auth.TwitterAuthProvider();
-    try { return await _auth.signInWithPopup(provider); }
-    catch (e) { throw new Error(_sanitizeError(e.code)); }
-  }
-
   async function signInWithEmail(email, password) {
     if (!_auth) throw new Error('Firebase not configured. Please set up FIREBASE_CONFIG in auth.js.');
     const limited = _isRateLimited();
@@ -431,18 +412,6 @@ const Auth = (() => {
           </svg>
           Continue with Google
         </button>
-        <button class="auth-provider-btn auth-apple" id="btn-apple">
-          <svg class="provider-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" fill="currentColor"/>
-          </svg>
-          Continue with Apple
-        </button>
-        <button class="auth-provider-btn auth-twitter" id="btn-twitter">
-          <svg class="provider-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" fill="currentColor"/>
-          </svg>
-          Continue with X
-        </button>
       </div>
       <div class="auth-divider"><span>or</span></div>
     `;
@@ -538,8 +507,6 @@ const Auth = (() => {
     }
 
     _providerGuard('btn-google',  signInWithGoogle);
-    _providerGuard('btn-apple',   signInWithApple);
-    _providerGuard('btn-twitter', signInWithTwitter);
 
     // ── Email form ──
     const form = document.getElementById('auth-form');
@@ -595,8 +562,6 @@ const Auth = (() => {
   return {
     init:            _init,
     signInWithGoogle,
-    signInWithApple,
-    signInWithTwitter,
     signInWithEmail,
     registerWithEmail,
     continueAsGuest,


### PR DESCRIPTION
Remove Apple Sign-In and X (Twitter) OAuth from the authentication module, keeping only Google OAuth and Email/Password sign-in methods.

Changes:
- Remove signInWithApple() and signInWithTwitter() functions from auth.js
- Remove Apple and Twitter sign-in buttons from the auth modal UI
- Remove Apple/Twitter event bindings in _bindModalEvents()
- Remove Apple/Twitter from the Auth public API
- Remove .auth-apple and .auth-twitter CSS rules from auth.css
- Update setup comments to reflect remaining providers
- Update README.md to list only Google OAuth + email/password

Closes #12

https://claude.ai/code/session_0117ZZCu4CHbpoSD29R6iacn