### PR TITLE
Force Node.js 24 for GitHub Actions to remove Node.js 20 deprecation …

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,9 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…warning

Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var at workflow level to use GitHub's official solution for the Node.js 20 deprecation.

https://claude.ai/code/session_01AJj7e7yAnvgzcYj3vozu4r