### PR TITLE
fix: resolve all remaining Firebase configuration errors

### DIFF
--- a/build.js
+++ b/build.js
@@ -33,11 +33,35 @@ if (!fs.existsSync(distDir)) {
 const versionFile = path.join(distDir, 'version.json');
 fs.writeFileSync(versionFile, JSON.stringify(versionData, null, 2) + '\n');
 
+// ── Read Firebase config from environment variables ───────────
+// The deploy workflow passes VITE_FIREBASE_* secrets as env vars.
+// We inject them inline into index.html as window.SQFLOW_FIREBASE_CONFIG
+// so that auth.js (a plain script, not an ES module) can read them.
+const firebaseConfig = {
+  apiKey:            process.env.VITE_FIREBASE_API_KEY            || '',
+  authDomain:        process.env.VITE_FIREBASE_AUTH_DOMAIN        || '',
+  projectId:         process.env.VITE_FIREBASE_PROJECT_ID         || '',
+  storageBucket:     process.env.VITE_FIREBASE_STORAGE_BUCKET     || '',
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '',
+  appId:             process.env.VITE_FIREBASE_APP_ID             || '',
+};
+
+const hasFirebaseConfig = firebaseConfig.apiKey && firebaseConfig.apiKey !== 'your_api_key_here';
+
 // ── Copy static assets into dist/ ────────────────────────────
 const staticFiles = ['index.html', 'app.js', 'auth.js', 'auth.css', 'style.css'];
 for (const file of staticFiles) {
   const src = path.join(__dirname, file);
-  if (fs.existsSync(src)) {
+  if (!fs.existsSync(src)) continue;
+
+  if (file === 'index.html' && hasFirebaseConfig) {
+    // Inject window.SQFLOW_FIREBASE_CONFIG before auth.js loads
+    let html = fs.readFileSync(src, 'utf8');
+    const configScript = `  <script>window.SQFLOW_FIREBASE_CONFIG = ${JSON.stringify(firebaseConfig)};</script>\n`;
+    html = html.replace('  <!-- Auth module must load before app.js', `${configScript}  <!-- Auth module must load before app.js`);
+    fs.writeFileSync(path.join(distDir, file), html);
+    console.log('[build] Firebase config injected into index.html');
+  } else {
     fs.copyFileSync(src, path.join(distDir, file));
   }
 }

--- a/src/lib/firebase-config.js
+++ b/src/lib/firebase-config.js
@@ -1,8 +1,0 @@
-export const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
-};


### PR DESCRIPTION
The build script was never injecting Firebase credentials into the built index.html. Fixed by reading VITE_FIREBASE_* env vars at build time and injecting window.SQFLOW_FIREBASE_CONFIG inline.

Closes #12

Generated with [Claude Code](https://claude.ai/code)