### PR TITLE
fix: restore Google login button after logout

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -447,6 +447,7 @@ const Auth = (() => {
 
   function _showAuthModal() {
     if (!_modal) _buildModal();
+    else _rebuildModal();
     _modal.style.display = 'flex';
   }
 


### PR DESCRIPTION
The Google button was stuck in a disabled "Signing in…" state after logout because _providerGuard only restored button HTML on error, never on success. Fixed by calling _rebuildModal() in _showAuthModal() so every modal open resets all button states from scratch.

Closes #12

Generated with [Claude Code](https://claude.ai/code)