### PR TITLE
fix: resolve #12 — isolate active trades and history per authenticate…

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -140,6 +140,7 @@ const Auth = (() => {
   let _cbQueue = [];
   let _mode    = 'signin';   // 'signin' | 'register'
   let _modal   = null;
+  let _wasExplicitGuest = false;  // true only when continueAsGuest() was called this session
 
   // ── Initialization ─────────────────────────────────────────
   async function _init() {
@@ -187,14 +188,17 @@ const Auth = (() => {
       // internally via its SDK. The access token is short-lived and the
       // refresh token is managed securely by the Firebase SDK.
       _auth.onAuthStateChanged(async user => {
-        const wasGuest = _guest && !_user;
         const prevUser = _user;  // capture before update to detect explicit logouts
         _user  = user;
         _guest = !user;
         _ready = true;
 
-        if (user && wasGuest) {
+        if (user && _wasExplicitGuest) {
           // Mid-session guest → account conversion: migrate session data first.
+          // Only runs when the user explicitly chose "Continue as Guest" this session,
+          // not on every sign-in after logout or page reload (which would risk migrating
+          // a previous authenticated user's leftover localStorage data).
+          _wasExplicitGuest = false;
           await _migrateGuestData();
         }
 
@@ -372,6 +376,7 @@ const Auth = (() => {
 
   function continueAsGuest() {
     _guest = true;
+    _wasExplicitGuest = true;  // allows data migration if user later signs in this session
     _hideAuthModal();
     _renderGuestBanner(true);
     _renderHeaderUser(null);
@@ -379,6 +384,16 @@ const Auth = (() => {
 
   async function signOut() {
     if (_auth && _user) {
+      // Eagerly clear local trade data BEFORE calling _auth.signOut() so the
+      // cleanup is guaranteed regardless of when onAuthStateChanged fires.
+      // Without this, a race condition allows the next user's session to
+      // inherit or migrate the previous user's localStorage trades.
+      localStorage.removeItem('sqFlow_activeTrades');
+      localStorage.removeItem('sqFlow_tradeHistory');
+      if (typeof state              !== 'undefined') state.activeTrades = [];
+      if (typeof stopTradeMonitor    === 'function') stopTradeMonitor();
+      if (typeof renderTradeMonitors === 'function') renderTradeMonitors();
+      if (typeof renderTradeHistory  === 'function') renderTradeHistory();
       try { await _auth.signOut(); } catch (_) {}
     }
     _guest = true;


### PR DESCRIPTION
…d user

Two bugs allowed one user's trade data to bleed into another's session:

1. Race condition in signOut(): _user was set to null AFTER _auth.signOut() was awaited, but onAuthStateChanged(null) could fire before that line executed. This meant prevUser === null in the callback, so the localStorage cleanup branch (else if prevUser !== null) was skipped, leaving the previous user's trades in localStorage.

   Fix: eagerly clear localStorage and in-memory state *before* calling _auth.signOut(), so cleanup is guaranteed regardless of callback timing.

2. Spurious data migration: after a logout the module variables (_user=null, _guest=true) look identical to the initial page-load state. When the next user signed in, wasGuest evaluated to true and _migrateGuestData() ran, uploading the leftover localStorage trades into the new user's Firestore before _syncFromCloud() could overwrite them.

   Fix: replace the wasGuest heuristic with an explicit _wasExplicitGuest flag that is only set when continueAsGuest() is called. Migration now runs only when a user genuinely chose Guest mode and then signs in.

Firestore structure is unchanged: users/{uid}/state/{activeTrades,tradeHistory} UI is unchanged — only data isolation logic is affected.

Closes #12

https://claude.ai/code/session_01JQ7Xad32uH81DXg6FStqvx