### PR TITLE
feat: persist active trades & history per user UID in Firestore

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -300,7 +300,16 @@ const Auth = (() => {
         }
       }
     } catch (e) {
-      console.error('[SqFlow Auth] Cloud sync failed:', e);
+      if (e.code === 'permission-denied') {
+        console.error(
+          '[SqFlow Auth] Firestore permission denied on sync. ' +
+          'Go to Firebase Console → Firestore Database → Rules and deploy the rules from firestore.rules ' +
+          '(or run: firebase deploy --only firestore:rules). ' +
+          'Falling back to localStorage for this session.'
+        );
+      } else {
+        console.error('[SqFlow Auth] Cloud sync failed:', e);
+      }
       // On error, keep localStorage if it belongs to this user; clear it otherwise.
       if (storedUid !== uid) {
         localStorage.setItem('sqFlow_activeTrades', JSON.stringify([]));
@@ -310,6 +319,11 @@ const Auth = (() => {
 
     // Tag localStorage so returning logins can detect same-user data.
     localStorage.setItem(_AUTH_KEYS.USER_ID, uid);
+
+    // Ensure the schema version is set so that loadTrades() does not run the
+    // v1→v2 migration and accidentally wipe the data we just restored from
+    // Firestore (migration runs whenever sqFlow_schemaVersion is not '2').
+    localStorage.setItem('sqFlow_schemaVersion', '2');
 
     // Reload app data from updated localStorage
     if (typeof loadTrades          === 'function') loadTrades();
@@ -457,7 +471,14 @@ const Auth = (() => {
                .collection('state').doc('activeTrades')
                .set({ trades, updatedAt: firebase.firestore.FieldValue.serverTimestamp() });
       return true;
-    } catch (e) { console.error('[SqFlow Auth] saveActiveTrades:', e); return false; }
+    } catch (e) {
+      if (e.code === 'permission-denied') {
+        console.error('[SqFlow Auth] saveActiveTrades: Firestore permission denied. Deploy firestore.rules — trades saved to localStorage only.');
+      } else {
+        console.error('[SqFlow Auth] saveActiveTrades:', e);
+      }
+      return false;
+    }
   }
 
   async function saveTradeHistory(history) {
@@ -467,7 +488,14 @@ const Auth = (() => {
                .collection('state').doc('tradeHistory')
                .set({ history, updatedAt: firebase.firestore.FieldValue.serverTimestamp() });
       return true;
-    } catch (e) { console.error('[SqFlow Auth] saveTradeHistory:', e); return false; }
+    } catch (e) {
+      if (e.code === 'permission-denied') {
+        console.error('[SqFlow Auth] saveTradeHistory: Firestore permission denied. Deploy firestore.rules — history saved to localStorage only.');
+      } else {
+        console.error('[SqFlow Auth] saveTradeHistory:', e);
+      }
+      return false;
+    }
   }
 
   // ── Header user block ───────────────────────────────────────

--- a/build.js
+++ b/build.js
@@ -49,7 +49,7 @@ const firebaseConfig = {
 const hasFirebaseConfig = firebaseConfig.apiKey && firebaseConfig.apiKey !== 'your_api_key_here';
 
 // ── Copy static assets into dist/ ────────────────────────────
-const staticFiles = ['index.html', 'app.js', 'auth.js', 'auth.css', 'style.css'];
+const staticFiles = ['index.html', 'app.js', 'auth.js', 'auth.css', 'style.css', 'firebase.json', 'firestore.rules'];
 for (const file of staticFiles) {
   const src = path.join(__dirname, file);
   if (!fs.existsSync(src)) continue;

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Each authenticated user can only read and write their own data.
+    // Path: users/{uid}/state/{doc}  (activeTrades, tradeHistory)
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+  }
+}

--- a/index.html
+++ b/index.html
@@ -711,7 +711,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
 
   <!-- Auth module must load before app.js so Auth global is available -->
-  <script src="auth.js?v=1"></script>
+  <script src="auth.js?v=2"></script>
   <script src="app.js?v=13"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes silent Firestore write failures and a schema migration race that prevented trade data from persisting across devices and sessions.

## Changes

- `firestore.rules` — per-user security rules that allow each authenticated user to read/write only their own data
- `firebase.json` — Firebase CLI config for deploying rules
- `auth.js` — set schema version in `_syncFromCloud()` before calling `loadTrades()`; clear `permission-denied` error messages
- `index.html` — bumped `auth.js?v=1` —> `auth.js?v=2`
- `build.js` — copies `firebase.json` and `firestore.rules` to `dist/`

## Required one-time action

Deploy the Firestore rules (once):
- **Console**: Firebase Console → Firestore Database → Rules → paste `firestore.rules` content → Publish
- **CLI**: `firebase deploy --only firestore:rules`

Closes #12

Generated with [Claude Code](https://claude.ai/code)