### PR TITLE
feat: Add donation/support card to About tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -2087,3 +2087,39 @@ function init() {
 }
 
 init();
+
+// ── Support card: copy-to-clipboard ──────────────────────────────
+document.addEventListener('click', function (e) {
+  const btn = e.target.closest('.about-copy-btn');
+  if (!btn) return;
+  const addr = btn.dataset.addr;
+  if (!addr) return;
+  navigator.clipboard.writeText(addr).then(function () {
+    const original = btn.textContent;
+    btn.textContent = 'Copied';
+    btn.classList.add('copied');
+    btn.disabled = true;
+    setTimeout(function () {
+      btn.textContent = original;
+      btn.classList.remove('copied');
+      btn.disabled = false;
+    }, 2000);
+  }).catch(function () {
+    // Fallback for older browsers
+    const ta = document.createElement('textarea');
+    ta.value = addr;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try { document.execCommand('copy'); } catch (_) {}
+    document.body.removeChild(ta);
+    btn.textContent = 'Copied';
+    btn.classList.add('copied');
+    setTimeout(function () {
+      btn.textContent = 'Copy';
+      btn.classList.remove('copied');
+    }, 2000);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -706,6 +706,61 @@
             View GitHub Profile
           </a>
         </section>
+
+        <!-- Support / Donations card -->
+        <section class="about-card about-support-card" aria-label="Support the project">
+          <h2 class="about-support-title">Support</h2>
+          <p class="about-support-desc">
+            If this tool's been useful — or at least interesting — sending a bit of crypto this way keeps things running.
+            It funds time spent building, testing, automating, and occasionally breaking things in constructive ways.
+            Independent work on markets and tooling doesn't cost much, but it does cost something.
+          </p>
+          <div class="about-wallets">
+            <div class="about-wallet-item">
+              <div class="about-wallet-header">
+                <span class="about-wallet-name">Bitcoin</span>
+                <span class="about-wallet-network-badge">Bitcoin</span>
+              </div>
+              <div class="about-wallet-addr-wrap">
+                <code class="about-wallet-addr">bc1qptzvveeaga3al5zn5l0sgpycjkk4vcqfsg3nuv</code>
+                <button
+                  class="about-copy-btn"
+                  aria-label="Copy Bitcoin address"
+                  data-addr="bc1qptzvveeaga3al5zn5l0sgpycjkk4vcqfsg3nuv"
+                >Copy</button>
+              </div>
+            </div>
+            <div class="about-wallet-item">
+              <div class="about-wallet-header">
+                <span class="about-wallet-name">Polygon</span>
+                <span class="about-wallet-network-badge">Polygon</span>
+              </div>
+              <div class="about-wallet-addr-wrap">
+                <code class="about-wallet-addr">0x166F7ad3FE9ae83d270B056BBCEeD09B5171cdD6</code>
+                <button
+                  class="about-copy-btn"
+                  aria-label="Copy Polygon address"
+                  data-addr="0x166F7ad3FE9ae83d270B056BBCEeD09B5171cdD6"
+                >Copy</button>
+              </div>
+            </div>
+            <div class="about-wallet-item">
+              <div class="about-wallet-header">
+                <span class="about-wallet-name">Tron</span>
+                <span class="about-wallet-network-badge">Tron</span>
+              </div>
+              <div class="about-wallet-addr-wrap">
+                <code class="about-wallet-addr">TTqmXZE8KkFxC3ibwNWEo5LW6xx2uNUmyv</code>
+                <button
+                  class="about-copy-btn"
+                  aria-label="Copy Tron address"
+                  data-addr="TTqmXZE8KkFxC3ibwNWEo5LW6xx2uNUmyv"
+                >Copy</button>
+              </div>
+            </div>
+          </div>
+          <p class="about-wallet-notice">Send only through the correct network.</p>
+        </section>
       </main>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -2210,7 +2210,9 @@ html, body {
    ============================================================ */
 .about-main {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-lg);
   padding: var(--space-xl) var(--space-md);
 }
 
@@ -2294,4 +2296,128 @@ html, body {
 .about-github-btn:hover {
   background: #2563eb;
   transform: translateY(-1px);
+}
+
+/* Support card */
+.about-support-card {
+  text-align: left;
+  align-items: stretch;
+  animation: cardFadeIn var(--transition-slow) 0.1s both;
+}
+
+.about-support-title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 var(--space-sm);
+}
+
+.about-support-desc {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.about-wallets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}
+
+.about-wallet-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.about-wallet-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.about-wallet-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.about-wallet-network-badge {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: var(--radius-pill);
+  padding: 1px 8px;
+  line-height: 1.6;
+}
+
+.about-wallet-addr-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+}
+
+.about-wallet-addr {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  word-break: break-all;
+  line-height: var(--leading-normal);
+  user-select: all;
+}
+
+.about-copy-btn {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-family: var(--font);
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+  min-width: 52px;
+  text-align: center;
+}
+
+.about-copy-btn:hover,
+.about-copy-btn:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-dim);
+  outline: none;
+}
+
+.about-copy-btn.copied {
+  color: var(--success);
+  border-color: var(--long-border);
+  background: var(--long-dim);
+}
+
+.about-wallet-notice {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: var(--space-sm);
+  line-height: var(--leading-normal);
+}
+
+@media (max-width: 480px) {
+  .about-wallet-addr-wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .about-copy-btn {
+    align-self: flex-end;
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a crypto donation/support card to the **About** tab, natively integrated with the existing design system
- Copy-to-clipboard interaction for each wallet address with visual feedback
- Written in the site owner's voice: honest, understated, builder-minded — no hype, no cringe

## Changes

- **`index.html`** — New `<section class="about-support-card">` after the profile card, with Bitcoin, Polygon, and Tron wallet addresses and copy buttons
- **`style.css`** — `about-main` updated to `flex-direction: column` to stack cards; all support card styles use existing design tokens (`--bg-card`, `--font-mono`, `--accent`, `--radius-*`, `--space-*`, `cardFadeIn`)
- **`app.js`** — Delegated `click` handler on `.about-copy-btn`: copies address via Clipboard API, shows "Copied" state for 2s, resets; includes `execCommand` fallback for older browsers

## Design notes

- Matches existing card treatment exactly: same background, border, radius, padding, animation
- Addresses rendered in monospace (`--font-mono`) for readability; `word-break: break-all` ensures graceful wrapping on mobile
- Network labels styled as small pill badges (reusing existing badge pattern)
- Copy button uses transparent/accent hover pattern consistent with other secondary buttons
- Responsive: address row switches to column layout on ≤480px viewports
- Accessible: semantic `<section>` with `aria-label`, copy buttons have descriptive `aria-label` per coin, `.copied` state is communicated via button text change

Closes #18

https://claude.ai/code/session_01XMv2GHMHyA8nv5pZjjpUz7