### PR TITLE
fix: update donation wallet addresses in About tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,11 +722,11 @@
                 <span class="about-wallet-network-badge">Bitcoin</span>
               </div>
               <div class="about-wallet-addr-wrap">
-                <code class="about-wallet-addr">bc1qptzvveeaga3al5zn5l0sgpycjkk4vcqfsg3nuv</code>
+                <code class="about-wallet-addr">bc1q5tpwf4fwzv34p8ptz882w29e9t9w8l8cgmtay0</code>
                 <button
                   class="about-copy-btn"
                   aria-label="Copy Bitcoin address"
-                  data-addr="bc1qptzvveeaga3al5zn5l0sgpycjkk4vcqfsg3nuv"
+                  data-addr="bc1q5tpwf4fwzv34p8ptz882w29e9t9w8l8cgmtay0"
                 >Copy</button>
               </div>
             </div>
@@ -736,11 +736,11 @@
                 <span class="about-wallet-network-badge">Polygon</span>
               </div>
               <div class="about-wallet-addr-wrap">
-                <code class="about-wallet-addr">0x166F7ad3FE9ae83d270B056BBCEeD09B5171cdD6</code>
+                <code class="about-wallet-addr">0x03C03d7221838e6522DA56a998100f6858933322</code>
                 <button
                   class="about-copy-btn"
                   aria-label="Copy Polygon address"
-                  data-addr="0x166F7ad3FE9ae83d270B056BBCEeD09B5171cdD6"
+                  data-addr="0x03C03d7221838e6522DA56a998100f6858933322"
                 >Copy</button>
               </div>
             </div>
@@ -750,11 +750,11 @@
                 <span class="about-wallet-network-badge">Tron</span>
               </div>
               <div class="about-wallet-addr-wrap">
-                <code class="about-wallet-addr">TTqmXZE8KkFxC3ibwNWEo5LW6xx2uNUmyv</code>
+                <code class="about-wallet-addr">TWX9hR996CFMkXxZhA5oXXGgDXZTG3qzFg</code>
                 <button
                   class="about-copy-btn"
                   aria-label="Copy Tron address"
-                  data-addr="TTqmXZE8KkFxC3ibwNWEo5LW6xx2uNUmyv"
+                  data-addr="TWX9hR996CFMkXxZhA5oXXGgDXZTG3qzFg"
                 >Copy</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Updates the three donation wallet addresses in the About tab as requested in issue #18 comment.

### Changes in :
| Coin | New address |
|------|-------------|
| Bitcoin | `bc1q5tpwf4fwzv34p8ptz882w29e9t9w8l8cgmtay0` |
| Polygon | `0x03C03d7221838e6522DA56a998100f6858933322` |
| Tron | `TWX9hR996CFMkXxZhA5oXXGgDXZTG3qzFg` |

Both the visible `<code>` text and the `data-addr` attributes on copy buttons were updated for all three wallets. No other changes were made.

Closes #18