### PR TITLE
fix: align logged-in user badge in header (#104)

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -302,7 +302,6 @@
   display: none;
   align-items: center;
   gap: var(--space-sm);
-  margin-left: var(--space-md);
 }
 
 .user-avatar {

--- a/style.css
+++ b/style.css
@@ -153,6 +153,12 @@ html, body {
   gap: var(--space-md);
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
 .logo {
   font-size: var(--text-xl);
   font-weight: 800;


### PR DESCRIPTION
## Summary

Closes #104

The logged-in user badge/profile block was visually detached and awkwardly placed in the header because `.header-right` had **no desktop CSS definition** — it wasn't a flex container, so its three children fell back to block layout and didn't flow horizontally or align vertically.

## Root cause

`.header-left` was correctly defined as:
```css
.header-left { display: flex; align-items: center; gap: var(--space-md); }
```
But `.header-right` had no matching rule, causing:
- Children stacking instead of sitting side-by-side
- User badge floating at the block top instead of vertically centered
- Visual disconnect from the symbol selector and price area

## Changes

**`style.css`** — add `.header-right` desktop rule (mirrors `.header-left` pattern):
```css
.header-right {
  display: flex;
  align-items: center;
  gap: var(--space-md);
}
```

**`auth.css`** — remove `margin-left` from `#header-user` (parent gap now handles spacing consistently):
```css
/* removed: margin-left: var(--space-md); */
```

## Why the new placement is more balanced

All three right-side elements (user badge, asset selector, price block) now flow in a horizontal row with consistent `gap`-based spacing, vertically centered to match `.header-left`. The user identity block is anchored to the same composition as the symbol selector and price area. The fix is 6 lines, minimal, scoped, and reuses the exact existing layout pattern — no absolute positioning, no redesign.

https://claude.ai/code/session_012PfZA71Lf7GiL4Mjey1E2m