### PR TITLE
fix: replace native confirm() dialogs with custom styled modals (#106)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1151,13 +1151,20 @@ function getTradeHistory() {
 }
 
 function clearTradeHistory() {
-  if (!confirm('Delete all trade history? This cannot be undone.')) return;
-  localStorage.removeItem(STORAGE_KEYS.HISTORY);
-  // Delete all history docs from Firestore subcollection.
-  if (typeof Auth !== 'undefined' && !Auth.isGuest()) {
-    Auth.clearAllHistory().catch(e => console.warn('[clearHistory Firestore]', e));
-  }
-  renderTradeHistory();
+  showConfirmModal({
+    title:        'Clear trade history',
+    message:      'This will permanently remove all trade history from this device.',
+    confirmLabel: 'Clear history',
+    danger:       true,
+    onConfirm() {
+      localStorage.removeItem(STORAGE_KEYS.HISTORY);
+      // Delete all history docs from Firestore subcollection.
+      if (typeof Auth !== 'undefined' && !Auth.isGuest()) {
+        Auth.clearAllHistory().catch(e => console.warn('[clearHistory Firestore]', e));
+      }
+      renderTradeHistory();
+    },
+  });
 }
 
 function formatDuration(ms) {

--- a/auth.js
+++ b/auth.js
@@ -57,6 +57,61 @@ function escHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+// ── Custom confirmation modal ──────────────────────────────────
+// Replaces native browser confirm() with a styled in-app dialog.
+// Defined in auth.js (loads first) so both auth.js and app.js can use it.
+//
+// Usage:
+//   showConfirmModal({
+//     title:        'Log out',
+//     message:      'Are you sure you want to sign out of SqFlow?',
+//     confirmLabel: 'Sign out',   // optional, defaults to 'Confirm'
+//     danger:       false,        // optional, styles confirm btn as destructive
+//     onConfirm:    () => { ... } // called when user clicks confirm
+//   });
+function showConfirmModal({ title, message, confirmLabel = 'Confirm', danger = false, onConfirm }) {
+  const overlay = document.createElement('div');
+  overlay.className = 'confirm-modal-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', 'confirm-modal-title');
+
+  overlay.innerHTML = `
+    <div class="confirm-modal">
+      <div class="confirm-modal-title" id="confirm-modal-title">${escHtml(title)}</div>
+      <p class="confirm-modal-message">${escHtml(message)}</p>
+      <div class="confirm-modal-actions">
+        <button class="confirm-modal-cancel" type="button">Cancel</button>
+        <button class="confirm-modal-confirm${danger ? ' danger' : ''}" type="button">${escHtml(confirmLabel)}</button>
+      </div>
+    </div>
+  `;
+
+  function close() {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') close();
+  }
+
+  overlay.querySelector('.confirm-modal-cancel').addEventListener('click', close);
+  overlay.querySelector('.confirm-modal-confirm').addEventListener('click', () => {
+    close();
+    onConfirm();
+  });
+  // Clicking the backdrop (overlay itself, not the dialog) closes the modal.
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+
+  document.addEventListener('keydown', onKey);
+  document.body.appendChild(overlay);
+  // Focus the cancel button by default for safety.
+  overlay.querySelector('.confirm-modal-cancel').focus();
+}
+
 // ── Firebase project configuration ───────────────────────────
 // Set window.SQFLOW_FIREBASE_CONFIG before this script loads to enable
 // Google OAuth and email/password sign-in. Without it, the app runs in
@@ -711,7 +766,12 @@ const Auth = (() => {
     `;
     wrap.style.display = 'flex';
     document.getElementById('signout-btn').addEventListener('click', () => {
-      if (confirm('Sign out of SqFlow?')) signOut();
+      showConfirmModal({
+        title:        'Log out',
+        message:      'Are you sure you want to sign out of SqFlow?',
+        confirmLabel: 'Sign out',
+        onConfirm:    signOut,
+      });
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -2427,3 +2427,93 @@ html, body {
     align-self: flex-end;
   }
 }
+
+/* ============================================================
+   CONFIRM MODAL  (replaces native browser confirm() dialogs)
+   ============================================================ */
+.confirm-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.60);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9000;
+  padding: var(--space-md);
+  animation: confirmOverlayIn var(--transition-fast) ease;
+}
+
+@keyframes confirmOverlayIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.confirm-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-xl);
+  width: 100%;
+  max-width: 380px;
+  animation: confirmModalIn var(--transition-fast) ease;
+}
+
+@keyframes confirmModalIn {
+  from { opacity: 0; transform: translateY(-8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+.confirm-modal-title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: var(--space-sm);
+  letter-spacing: -0.2px;
+}
+
+.confirm-modal-message {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-xl);
+}
+
+.confirm-modal-actions {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: flex-end;
+}
+
+.confirm-modal-cancel {
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: border-color var(--transition-base), color var(--transition-base);
+  min-height: 38px;
+  font-family: var(--font);
+}
+.confirm-modal-cancel:hover { border-color: var(--border-light); color: var(--text-primary); }
+
+.confirm-modal-confirm {
+  background: var(--accent);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: opacity var(--transition-base);
+  min-height: 38px;
+  font-family: var(--font);
+}
+.confirm-modal-confirm:hover { opacity: 0.88; }
+.confirm-modal-confirm.danger {
+  background: var(--danger);
+}


### PR DESCRIPTION
## Summary

Closes #106

Replaces the two browser-native `confirm()` dialogs with a custom in-app confirmation modal that matches the existing dark dashboard design system.

### Changes

- **`auth.js`** — Added `showConfirmModal()` utility (defined here since `auth.js` loads first; available to both scripts at runtime). Replaced the native `confirm()` in the sign-out button handler with a clean modal.
- **`app.js`** — Replaced native `confirm()` in `clearTradeHistory()` with a destructive-styled modal.
- **`style.css`** — Added `.confirm-modal-overlay` / `.confirm-modal` CSS using existing design tokens only (`--bg-card`, `--border-light`, `--danger`, `--accent`, `--shadow-lg`, `--radius-lg`, `--transition-fast`, etc.).

### How native dialogs were replaced

| Location | Before | After |
|---|---|---|
| Sign out (auth.js:714) | `confirm('Sign out of SqFlow?')` | `showConfirmModal({ title: 'Log out', … })` |
| Clear history (app.js:1154) | `confirm('Delete all trade history?…')` | `showConfirmModal({ title: 'Clear trade history', danger: true, … })` |

### Reusable modal pattern

`showConfirmModal({ title, message, confirmLabel, danger, onConfirm })` — lightweight, zero-dependency, injects a DOM overlay and cleans up after itself. Keyboard accessible: Escape closes, focus lands on Cancel by default, backdrop click dismisses.

### Why this better matches the design

- Uses all existing CSS tokens — colours, radius, shadows, typography, transitions
- Animate-in with a subtle fade + scale that matches the app's polish level
- Danger variant (`--danger` background) clearly signals destructive action for Clear history
- Log out modal is clean and simple — no drama
- No external libraries, no redesign of unrelated areas