### PR TITLE
Improve dashboard header layout and visual balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,19 +29,21 @@
       <div class="header-right">
         <!-- User avatar + name + sign-out (shown when authenticated) -->
         <div id="header-user"></div>
-        <div class="asset-selector-wrap">
-          <button class="asset-selector-trigger" id="asset-selector-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Select trading asset">
-            <span class="asset-label" id="asset-label">BTC / USD</span>
-            <span class="asset-selector-arrow" aria-hidden="true">&#x25BE;</span>
-          </button>
-          <div class="asset-selector-dropdown" id="asset-selector-dropdown" role="listbox" aria-label="Available assets"></div>
-        </div>
-        <div class="asset-price-block">
-          <div class="asset-price-row">
-            <span class="asset-price" id="asset-price" aria-label="Current price" role="status">—</span>
-            <span class="market-status open" id="market-status" role="status">Open</span>
+        <div class="header-trading">
+          <div class="asset-selector-wrap">
+            <button class="asset-selector-trigger" id="asset-selector-trigger" aria-haspopup="listbox" aria-expanded="false" aria-label="Select trading asset">
+              <span class="asset-label" id="asset-label">BTC / USD</span>
+              <span class="asset-selector-arrow" aria-hidden="true">&#x25BE;</span>
+            </button>
+            <div class="asset-selector-dropdown" id="asset-selector-dropdown" role="listbox" aria-label="Available assets"></div>
           </div>
-          <span class="asset-change" id="asset-change" aria-label="Price change"></span>
+          <div class="asset-price-block">
+            <div class="asset-price-row">
+              <span class="asset-price" id="asset-price" aria-label="Current price" role="status">—</span>
+              <span class="market-status open" id="market-status" role="status">Open</span>
+            </div>
+            <span class="asset-change" id="asset-change" aria-label="Price change"></span>
+          </div>
         </div>
       </div>
     </header>

--- a/style.css
+++ b/style.css
@@ -159,6 +159,19 @@ html, body {
   gap: var(--space-md);
 }
 
+.header-trading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+/* Show a visual separator between the user identity block and trading data
+   only when a user is authenticated (user block is non-empty). */
+#header-user:not(:empty) + .header-trading {
+  padding-left: var(--space-md);
+  border-left: 1px solid var(--border);
+}
+
 .logo {
   font-size: var(--text-xl);
   font-weight: 800;
@@ -180,8 +193,11 @@ html, body {
 
 .header-meta {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-md);
+  padding-left: var(--space-md);
+  border-left: 1px solid var(--border);
 }
 
 /* Segmented control — single connected pill */


### PR DESCRIPTION
## Summary

- **Flatten left side**: Changed `.header-meta` from `flex-direction: column` to `flex-direction: row` so the strategy tag and timeframe selector sit on the same horizontal baseline as the logo. Added a subtle `border-left` separator to anchor the controls visually away from the brand.
- **Group trading data**: Wrapped the asset selector and price/status block inside a new `.header-trading` container, making the market data feel cohesive rather than two separate floating elements.
- **Conditional right-side separator**: Uses the CSS rule `#header-user:not(:empty) + .header-trading` to display a vertical divider between the user identity block and the trading data — only when a user is authenticated. Invisible in guest mode with no JS changes required.

## What was off before

1. The strategy tag stacked above the timeframe buttons in a column, breaking the single-baseline composition.
2. No visual distinction between user identity (avatar/name/logout) and market data (symbol/price/status) on the right side.
3. Asset selector and price block were sibling elements with no grouping — they felt like separate floaters.

## What changed

- `index.html`: wrapped asset-selector-wrap + asset-price-block in `<div class="header-trading">`
- `style.css`: updated `.header-meta` to row layout with separator, added `.header-trading` group styles, added conditional separator rule

## Test plan

- [ ] Verify strategy tag and timeframe selector appear on the same row as the logo (guest and authenticated)
- [ ] Verify no separator appears between empty user block and trading data in guest mode
- [ ] Verify separator appears between user block and trading data when authenticated
- [ ] Verify asset selector dropdown still opens/closes correctly
- [ ] Verify timeframe switching still works
- [ ] Check layout on narrow viewports

Closes #108

https://claude.ai/code/session_01Ss74fEoyRLJzXKvrQfNyoH