### PR TITLE
fix: show timeframe selector only on Dashboard tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -1796,6 +1796,11 @@ function switchTab(tab) {
   // It shows the selected pair's price which is meaningless on Active Trades / History.
   const priceBlock = document.querySelector('.asset-price-block');
   if (priceBlock) priceBlock.style.display = tab === 'dashboard' ? '' : 'none';
+
+  // Hide timeframe selector on non-dashboard tabs — the control affects dashboard
+  // signal data only and has no effect on other tabs.
+  const tfSelector = document.querySelector('.tf-selector');
+  if (tfSelector) tfSelector.style.display = tab === 'dashboard' ? '' : 'none';
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Hides `.tf-selector` on non-Dashboard tabs (Active Trades, History, Strategy, About)
- Follows the exact same pattern already used for `.asset-selector-wrap` and `.asset-price-block` in `switchTab()`
- Single 4-line addition in `app.js` — no HTML or CSS changes needed

## Changes

**`app.js` — `switchTab()` function**

Added the conditional show/hide for `.tf-selector`, consistent with the existing header control visibility logic:

```js
const tfSelector = document.querySelector('.tf-selector');
if (tfSelector) tfSelector.style.display = tab === 'dashboard' ? '' : 'none';
```

## Result

The timeframe selector (1H / 4H / 1D / 1W) now only appears when the Dashboard tab is active. On all other tabs the header is clean — only the logo and strategy tag remain on the left side.

Closes #108

https://claude.ai/code/session_01XhUwQfWh3vdWqSz2MoiLCD