### PR TITLE
fix: integrate Twelve Data as primary provider for FX & futures + last-known-good price

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,26 +28,26 @@ const STRATEGY = {
 
 // ── Asset registry ─────────────────────────────────────────
 const ASSETS = {
-  // Futures — Indices (Yahoo Finance proxy for data)
-  'ES1!':  { name: 'S&P 500 E-mini',     category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:ES1!',  yahoo: 'ES=F' },
-  'NQ1!':  { name: 'Nasdaq 100 E-mini',   category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:NQ1!',  yahoo: 'NQ=F' },
-  'YM1!':  { name: 'Dow Jones E-mini',    category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CBOT_MINI:YM1!', yahoo: 'YM=F' },
-  'RTY1!': { name: 'Russell 2000 E-mini', category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:RTY1!', yahoo: 'RTY=F' },
-  'DAX1!': { name: 'DAX Futures',         category: 'Futures — Indices',      market: 'eurex', bitfinex: null, binance: null, tradingview: 'EUREX:FDAX1!',   yahoo: '^GDAXI' },
-  'NKD1!': { name: 'Nikkei 225 Futures',  category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME:NKD1!',      yahoo: 'NKD=F' },
-  // Futures — Commodities (Yahoo Finance proxy for data)
-  'GC1!':  { name: 'Gold',                category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:GC1!',     yahoo: 'GC=F' },
-  'SI1!':  { name: 'Silver',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:SI1!',     yahoo: 'SI=F' },
-  'CL1!':  { name: 'Crude Oil WTI',       category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:CL1!',     yahoo: 'CL=F' },
-  'NG1!':  { name: 'Natural Gas',         category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:NG1!',     yahoo: 'NG=F' },
-  'HG1!':  { name: 'Copper',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:HG1!',     yahoo: 'HG=F' },
-  // FX Pairs (Yahoo Finance proxy for data)
-  'GBP/USD': { name: 'British Pound',     category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:GBPUSD', yahoo: 'GBPUSD=X' },
-  'EUR/USD': { name: 'Euro',              category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:EURUSD', yahoo: 'EURUSD=X' },
-  'USD/JPY': { name: 'Japanese Yen',      category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDJPY', yahoo: 'JPY=X' },
-  'AUD/USD': { name: 'Australian Dollar', category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:AUDUSD', yahoo: 'AUDUSD=X' },
-  'USD/CHF': { name: 'Swiss Franc',       category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDCHF', yahoo: 'CHF=X' },
-  // Crypto (Bitfinex + Binance)
+  // Futures — Indices (Twelve Data primary, Yahoo Finance fallback)
+  'ES1!':  { name: 'S&P 500 E-mini',     category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:ES1!',  yahoo: 'ES=F',    twelvedata: 'ES1!' },
+  'NQ1!':  { name: 'Nasdaq 100 E-mini',   category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:NQ1!',  yahoo: 'NQ=F',    twelvedata: 'NQ1!' },
+  'YM1!':  { name: 'Dow Jones E-mini',    category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CBOT_MINI:YM1!', yahoo: 'YM=F',    twelvedata: 'YM1!' },
+  'RTY1!': { name: 'Russell 2000 E-mini', category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME_MINI:RTY1!', yahoo: 'RTY=F',   twelvedata: 'RTY1!' },
+  'DAX1!': { name: 'DAX Futures',         category: 'Futures — Indices',      market: 'eurex', bitfinex: null, binance: null, tradingview: 'EUREX:FDAX1!',   yahoo: '^GDAXI',  twelvedata: 'DAX1!' },
+  'NKD1!': { name: 'Nikkei 225 Futures',  category: 'Futures — Indices',      market: 'cme',   bitfinex: null, binance: null, tradingview: 'CME:NKD1!',      yahoo: 'NKD=F',   twelvedata: 'NKD1!' },
+  // Futures — Commodities (Twelve Data primary, Yahoo Finance fallback)
+  'GC1!':  { name: 'Gold',                category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:GC1!',     yahoo: 'GC=F',    twelvedata: 'GC1!' },
+  'SI1!':  { name: 'Silver',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:SI1!',     yahoo: 'SI=F',    twelvedata: 'SI1!' },
+  'CL1!':  { name: 'Crude Oil WTI',       category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:CL1!',     yahoo: 'CL=F',    twelvedata: 'CL1!' },
+  'NG1!':  { name: 'Natural Gas',         category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'NYMEX:NG1!',     yahoo: 'NG=F',    twelvedata: 'NG1!' },
+  'HG1!':  { name: 'Copper',              category: 'Futures — Commodities',  market: 'cme',   bitfinex: null, binance: null, tradingview: 'COMEX:HG1!',     yahoo: 'HG=F',    twelvedata: 'HG1!' },
+  // FX Pairs (Twelve Data primary, Yahoo Finance fallback)
+  'GBP/USD': { name: 'British Pound',     category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:GBPUSD', yahoo: 'GBPUSD=X', twelvedata: 'GBP/USD' },
+  'EUR/USD': { name: 'Euro',              category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:EURUSD', yahoo: 'EURUSD=X', twelvedata: 'EUR/USD' },
+  'USD/JPY': { name: 'Japanese Yen',      category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDJPY', yahoo: 'JPY=X',    twelvedata: 'USD/JPY' },
+  'AUD/USD': { name: 'Australian Dollar', category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:AUDUSD', yahoo: 'AUDUSD=X', twelvedata: 'AUD/USD' },
+  'USD/CHF': { name: 'Swiss Franc',       category: 'FX Pairs', market: 'forex', bitfinex: null, binance: null, tradingview: 'FX:USDCHF', yahoo: 'CHF=X',    twelvedata: 'USD/CHF' },
+  // Crypto (Bitfinex + Binance — untouched)
   'BTC/USD': { name: 'Bitcoin',   category: 'Crypto', market: 'crypto', bitfinex: 'tBTCUSD', binance: 'BTCUSDT', tradingview: null },
   'ETH/USD': { name: 'Ethereum',  category: 'Crypto', market: 'crypto', bitfinex: 'tETHUSD', binance: 'ETHUSDT', tradingview: null },
   'SOL/USD': { name: 'Solana',    category: 'Crypto', market: 'crypto', bitfinex: 'tSOLUSD', binance: 'SOLUSDT', tradingview: null },
@@ -160,16 +160,23 @@ function getApiUrls(tf, assetKey) {
     };
   }
 
-  // Non-crypto assets (Futures, FX): server-side Yahoo Finance proxy with CORS fallback
+  // Non-crypto assets (Futures, FX): Twelve Data primary, Yahoo Finance fallback
   if (asset && asset.yahoo) {
     const needs4h = tf === '4h';
     const yahooTf = needs4h ? '1h' : ({ '1h': '1h', '4h': '4h', '1d': '1d', '1w': '1wk' }[tf] || '4h');
     const range   = needs4h ? '2y' : ({ '1h': '1mo', '4h': '3mo', '1d': '2y', '1w': '10y' }[tf] || '3mo');
     const yahooSymbol = asset.yahoo;
     const yahooDirectUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(yahooSymbol)}?interval=${yahooTf}&range=${range}`;
+    // Twelve Data interval mapping (supports 4h natively — no aggregation needed)
+    const tdTf = { '1h': '1h', '4h': '4h', '1d': '1day', '1w': '1week' }[tf] || '4h';
+    const symbolKey = assetKey || state.currentAsset;
     return {
       provider: 'yahoo',
-      proxyUrl: `/api/market-data?symbol=${encodeURIComponent(assetKey || state.currentAsset)}&interval=${tf === '4h' ? '4h' : yahooTf}&range=${tf === '4h' ? '3mo' : range}`,
+      // Twelve Data proxy URL (primary for non-crypto when API key is configured)
+      tdProxyUrl: asset.twelvedata
+        ? `/api/td-market-data?symbol=${encodeURIComponent(symbolKey)}&interval=${tdTf}`
+        : null,
+      proxyUrl: `/api/market-data?symbol=${encodeURIComponent(symbolKey)}&interval=${tf === '4h' ? '4h' : yahooTf}&range=${tf === '4h' ? '3mo' : range}`,
       directUrl: yahooDirectUrl,
       needs4h,
     };
@@ -195,6 +202,12 @@ const state = {
 // Populated by run() and the 30 s monitor so closeTrade() can look up
 // the correct last price even when a different asset is currently displayed.
 const candleCache = {};
+
+// Last-known-good price store for FX and futures instruments.
+// On a successful fetch the latest close price and timestamp are saved here.
+// On a failed fetch, the stored value is shown instead of leaving the panel blank.
+// Keyed by assetKey (e.g. 'ES1!', 'EUR/USD').
+const lastKnownGoodPrices = {};
 
 // ============================================================
 // MATH HELPERS
@@ -1381,6 +1394,18 @@ function looksLikeHtml(text) {
 async function fetchYahooCandles(urls, key) {
   const errors = [];
 
+  // Strategy 0: Twelve Data proxy (primary — faster, 4h native, more reliable)
+  if (urls.tdProxyUrl) {
+    try {
+      const candles = await fetchTwelveDataCandles(urls.tdProxyUrl, key);
+      console.log(`[fetchNonCrypto] Twelve Data succeeded for ${key} (${candles.length} candles)`);
+      return candles;
+    } catch (err) {
+      console.warn(`[fetchNonCrypto] Twelve Data failed for ${key}:`, err.message);
+      errors.push(`Twelve Data: ${err.message}`);
+    }
+  }
+
   // Strategy 1: Try local server proxy (works when running via `node server.js`)
   try {
     const res = await fetch(urls.proxyUrl);
@@ -1450,6 +1475,36 @@ async function fetchYahooCandles(urls, key) {
   }
 
   throw new Error(`Market data unavailable for ${key}. Please try again later.`);
+}
+
+// Fetch candles from the Twelve Data server proxy.
+// Returns a normalized OHLCV array on success, or throws on failure.
+async function fetchTwelveDataCandles(tdProxyUrl, key) {
+  const TIMEOUT_MS = 8000;
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(tdProxyUrl, { signal: controller.signal });
+    clearTimeout(tid);
+    const text = await res.text();
+    if (looksLikeHtml(text)) throw new Error('Twelve Data proxy returned HTML (not available)');
+    if (!res.ok) {
+      let msg = `Twelve Data proxy HTTP ${res.status}`;
+      try { msg = JSON.parse(text).error || msg; } catch (_) { /* ignore */ }
+      throw new Error(msg);
+    }
+    const data = JSON.parse(text);
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error(`Empty response from Twelve Data proxy for ${key}`);
+    }
+    if (data.length < 50) {
+      throw new Error(`Insufficient data from Twelve Data (${data.length} candles) for ${key}`);
+    }
+    return data;
+  } catch (err) {
+    clearTimeout(tid);
+    throw err;
+  }
 }
 
 // ============================================================
@@ -1625,6 +1680,28 @@ function updateUI(r, capital) {
   const changePct = ((r.currentPrice - r.prevClose) / r.prevClose) * 100;
   changeEl.textContent = (changePct >= 0 ? '+' : '') + changePct.toFixed(2) + '%';
   changeEl.className   = 'asset-change ' + (changePct >= 0 ? 'up' : 'down');
+
+  // Last-known-good price: save on successful fetch for FX/futures fallback
+  const assetMeta = ASSETS[state.currentAsset];
+  if (assetMeta && assetMeta.market !== 'crypto' && r.currentPrice) {
+    lastKnownGoodPrices[state.currentAsset] = {
+      price:     r.currentPrice,
+      changePct,
+      fetchedAt: Date.now(),
+    };
+  }
+
+  // "Last updated" label — shown for FX and futures to indicate data freshness
+  const lastUpdatedEl = el('price-last-updated');
+  if (lastUpdatedEl) {
+    if (assetMeta && assetMeta.market !== 'crypto') {
+      const ts = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      lastUpdatedEl.textContent = `Updated ${ts}${USER_TZ_ABBR ? ' ' + USER_TZ_ABBR : ''}`;
+      lastUpdatedEl.className = 'price-last-updated';
+    } else {
+      lastUpdatedEl.textContent = '';
+    }
+  }
 
   // Signal
   setSignalCard(r.signal);
@@ -1839,6 +1916,8 @@ async function run() {
     if (priceEl) priceEl.textContent = '—';
     const changeEl = el('asset-change');
     if (changeEl) changeEl.textContent = '';
+    const lastUpdatedEl = el('price-last-updated');
+    if (lastUpdatedEl) lastUpdatedEl.textContent = '';
     // Hide sections that only make sense when the market is open
     setMarketSectionsVisible(false);
     btn.disabled    = false;
@@ -1884,9 +1963,32 @@ async function run() {
       if (retryBtn) retryBtn.addEventListener('click', manualRefresh);
     }
 
-    // Still update price display for context
+    // If a last-known-good price exists for this FX/futures asset, keep showing it
     const priceEl = el('asset-price');
-    if (priceEl) priceEl.textContent = '—';
+    const lkg = lastKnownGoodPrices[state.currentAsset];
+    if (priceEl) {
+      if (lkg) {
+        priceEl.textContent = '$' + fmt(lkg.price);
+        const changeEl = el('asset-change');
+        if (changeEl) {
+          changeEl.textContent = (lkg.changePct >= 0 ? '+' : '') + lkg.changePct.toFixed(2) + '%';
+          changeEl.className   = 'asset-change ' + (lkg.changePct >= 0 ? 'up' : 'down');
+        }
+        const lastUpdatedEl = el('price-last-updated');
+        if (lastUpdatedEl) {
+          const ageMs = Date.now() - lkg.fetchedAt;
+          const ageMins = Math.floor(ageMs / 60000);
+          const ts = new Date(lkg.fetchedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+          const label = ageMins > 0 ? `Last seen ${ts} (${ageMins}m ago)` : `Last seen ${ts}`;
+          lastUpdatedEl.textContent = label;
+          lastUpdatedEl.className = 'price-last-updated stale';
+        }
+      } else {
+        priceEl.textContent = '—';
+        const lastUpdatedEl = el('price-last-updated');
+        if (lastUpdatedEl) lastUpdatedEl.textContent = '';
+      }
+    }
     el('enter-trade-wrap')?.style && (el('enter-trade-wrap').style.display = 'none');
   } finally {
     btn.disabled    = false;

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
               <span class="market-status open" id="market-status" role="status">Open</span>
             </div>
             <span class="asset-change" id="asset-change" aria-label="Price change"></span>
+            <span class="price-last-updated" id="price-last-updated" aria-label="Price last updated time"></span>
           </div>
         </div>
       </div>

--- a/server.js
+++ b/server.js
@@ -32,9 +32,10 @@ function addSecurityHeaders(res) {
     [
       "default-src 'self'",
       "script-src 'self' https://www.gstatic.com",
-      // Allow connections to Firebase, Yahoo Finance, and crypto APIs
+      // Allow connections to Firebase, Yahoo Finance, Twelve Data, and crypto APIs
       "connect-src 'self' https://api-pub.bitfinex.com https://api.binance.com " +
         "https://query1.finance.yahoo.com https://api.allorigins.win https://corsproxy.io " +
+        "https://api.twelvedata.com " +
         "https://*.firebaseio.com https://identitytoolkit.googleapis.com " +
         "https://securetoken.googleapis.com",
       "style-src 'self' 'unsafe-inline'",
@@ -133,6 +134,32 @@ const YAHOO_SYMBOLS = {
   'USD/JPY': 'JPY=X',
   'AUD/USD': 'AUDUSD=X',
   'USD/CHF': 'CHF=X',
+};
+
+// ── Symbol mapping: internal keys → Twelve Data symbols ──────
+// Twelve Data supports 4h natively (no aggregation needed).
+// FX pairs use the standard "BASE/QUOTE" format.
+// Futures use their standard root symbol.
+const TWELVE_DATA_SYMBOLS = {
+  // Futures — Indices
+  'ES1!':  'ES1!',
+  'NQ1!':  'NQ1!',
+  'YM1!':  'YM1!',
+  'RTY1!': 'RTY1!',
+  'DAX1!': 'DAX1!',
+  'NKD1!': 'NKD1!',
+  // Futures — Commodities
+  'GC1!':  'GC1!',
+  'SI1!':  'SI1!',
+  'CL1!':  'CL1!',
+  'NG1!':  'NG1!',
+  'HG1!':  'HG1!',
+  // FX Pairs
+  'GBP/USD': 'GBP/USD',
+  'EUR/USD': 'EUR/USD',
+  'USD/JPY': 'USD/JPY',
+  'AUD/USD': 'AUD/USD',
+  'USD/CHF': 'USD/CHF',
 };
 
 // ── MIME types for static file serving ───────────────────────
@@ -305,6 +332,108 @@ async function handleMarketData(query, res) {
   }
 }
 
+// ── Twelve Data proxy handler ────────────────────────────────
+// Proxies requests to api.twelvedata.com so the browser never exposes the API key.
+// Supports the same interval/range parameters as the Yahoo proxy for drop-in use.
+// Twelve Data supports 4h natively — no server-side aggregation needed.
+
+const TD_VALID_INTERVALS = new Set(['1min', '5min', '15min', '30min', '1h', '2h', '4h', '1day', '1week', '1month']);
+
+async function handleTwelveData(query, res) {
+  const apiKey = process.env.TWELVE_DATA_API_KEY || '';
+  if (!apiKey) {
+    res.writeHead(503, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Twelve Data API key not configured on this server.' }));
+    return;
+  }
+
+  const symbol = query.symbol;
+  if (!symbol) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Missing required parameter: symbol' }));
+    return;
+  }
+
+  const tdSymbol = TWELVE_DATA_SYMBOLS[symbol];
+  if (!tdSymbol) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: `Unsupported symbol: ${symbol}. Available: ${Object.keys(TWELVE_DATA_SYMBOLS).join(', ')}` }));
+    return;
+  }
+
+  // Map our internal timeframe names to Twelve Data interval strings
+  const intervalMap = { '1h': '1h', '4h': '4h', '1d': '1day', '1w': '1week' };
+  const rawInterval = query.interval || '4h';
+  const interval = intervalMap[rawInterval] || (TD_VALID_INTERVALS.has(rawInterval) ? rawInterval : '4h');
+
+  // outputsize: max 5000; use 300 to match STRATEGY.CANDLE_LIMIT
+  const outputsize = Math.min(parseInt(query.outputsize, 10) || 300, 5000);
+
+  const tdUrl = `https://api.twelvedata.com/time_series?symbol=${encodeURIComponent(tdSymbol)}&interval=${interval}&outputsize=${outputsize}&order=ASC&apikey=${apiKey}`;
+
+  try {
+    console.log(`[td-proxy] ${symbol} → ${tdSymbol} (interval=${interval}, outputsize=${outputsize})`);
+    const { statusCode, body } = await httpsGet(tdUrl);
+
+    if (statusCode !== 200) {
+      console.warn(`[td-proxy] Twelve Data returned HTTP ${statusCode} for ${tdSymbol}`);
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: `Twelve Data returned HTTP ${statusCode} for ${symbol}.` }));
+      return;
+    }
+
+    const data = JSON.parse(body);
+
+    if (data.status === 'error' || !data.values || !Array.isArray(data.values) || data.values.length === 0) {
+      const msg = data.message || `No data available for ${symbol}.`;
+      console.warn(`[td-proxy] Twelve Data error for ${tdSymbol}:`, msg);
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: msg }));
+      return;
+    }
+
+    // Normalize Twelve Data response to our standard OHLCV format.
+    // Twelve Data returns datetimes as "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD" strings.
+    const candles = data.values
+      .map(v => {
+        const o = parseFloat(v.open);
+        const h = parseFloat(v.high);
+        const l = parseFloat(v.low);
+        const c = parseFloat(v.close);
+        const vol = parseFloat(v.volume) || 0;
+        if (isNaN(o) || isNaN(h) || isNaN(l) || isNaN(c)) return null;
+        return {
+          time:   new Date(v.datetime.replace(' ', 'T') + (v.datetime.length === 10 ? 'T00:00:00Z' : 'Z')).getTime(),
+          open:   o,
+          high:   h,
+          low:    l,
+          close:  c,
+          volume: vol,
+        };
+      })
+      .filter(Boolean);
+
+    if (candles.length === 0) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: `No valid candles for ${symbol}. Market may be closed or symbol unsupported.` }));
+      return;
+    }
+
+    console.log(`[td-proxy] ${symbol}: ${candles.length} candles returned`);
+
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=60',
+    });
+    res.end(JSON.stringify(candles));
+
+  } catch (err) {
+    console.error(`[td-proxy] Error fetching ${symbol}:`, err.message);
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: `Failed to fetch Twelve Data for ${symbol}. Please try again later.` }));
+  }
+}
+
 // ── Static file server ───────────────────────────────────────
 function serveStatic(pathname, res) {
   // Default to index.html
@@ -378,9 +507,15 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Route: /api/market-data
+  // Route: /api/market-data (Yahoo Finance proxy)
   if (pathname === '/api/market-data' && req.method === 'GET') {
     handleMarketData(query, res);
+    return;
+  }
+
+  // Route: /api/td-market-data (Twelve Data proxy)
+  if (pathname === '/api/td-market-data' && req.method === 'GET') {
+    handleTwelveData(query, res);
     return;
   }
 

--- a/style.css
+++ b/style.css
@@ -429,6 +429,20 @@ html, body {
 .asset-change.up   { color: var(--long); }
 .asset-change.down { color: var(--short); }
 
+/* Last-updated timestamp for FX and futures price data */
+.price-last-updated {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 1px;
+  min-height: 14px;
+}
+.price-last-updated.stale {
+  color: var(--warning);
+  opacity: 0.75;
+}
+
 .market-status {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Integrates **Twelve Data** as the primary market data provider for all FX pairs and futures instruments, replacing Yahoo Finance as the primary (Yahoo Finance is kept as fallback)
- Adds a **last-known-good price mechanism**: on any fetch failure, the most recently loaded price is preserved and shown with a stale timestamp — the price panel never goes blank
- Adds a **"Last updated" timestamp** in the header price block for FX/futures instruments, showing data freshness ("Updated HH:MM") or staleness ("Last seen HH:MM (Xm ago)")

## Changes

| File | What changed |
|------|-------------|
| `server.js` | New `/api/td-market-data` proxy endpoint (reads `TWELVE_DATA_API_KEY` from env, maps symbols, normalizes OHLCV); `TWELVE_DATA_SYMBOLS` map; CSP updated to allow `api.twelvedata.com` |
| `app.js` | `fetchTwelveDataCandles()` function; Twelve Data tried as Strategy 0 in `fetchYahooCandles()`; `lastKnownGoodPrices` map; last-known-good price displayed on error; `price-last-updated` label written in `updateUI()` and error handler; `twelvedata` field added to all FX/futures `ASSETS` entries; `getApiUrls()` generates `tdProxyUrl` |
| `index.html` | `<span id="price-last-updated">` added inside `.asset-price-block` |
| `style.css` | `.price-last-updated` and `.price-last-updated.stale` using existing design tokens |

## How Twelve Data was integrated

1. **Server proxy** (`server.js`): `handleTwelveData()` reads `TWELVE_DATA_API_KEY` from `process.env`, maps the internal asset key (e.g. `ES1!`) to the Twelve Data symbol via `TWELVE_DATA_SYMBOLS`, fetches `https://api.twelvedata.com/time_series?...`, normalizes the response to `{time, open, high, low, close, volume}` and returns the array. The API key never reaches the browser.

2. **Client-side routing** (`app.js`): `getApiUrls()` now includes a `tdProxyUrl` for all non-crypto assets. `fetchYahooCandles()` tries `fetchTwelveDataCandles(tdProxyUrl)` first (Strategy 0) before the existing Yahoo Finance proxy and CORS proxy fallbacks.

## How last-known-good price fallback works

- `lastKnownGoodPrices[assetKey]` stores `{price, changePct, fetchedAt}` after every successful non-crypto fetch (written in `updateUI()`)
- On a failed fetch, the `run()` error handler checks `lastKnownGoodPrices[state.currentAsset]`: if present, it restores the price and change% in the header and sets the label to `"Last seen HH:MM (Xm ago)"`; if absent, it shows `"—"` as before

## How "last updated" is shown

- On fresh fetch: `updateUI()` sets `#price-last-updated` to `"Updated HH:MM TZ"` (`.price-last-updated` class — muted text)
- On stale/error: error handler sets it to `"Last seen HH:MM (Xm ago)"` (`.price-last-updated.stale` class — warning amber, 75% opacity)
- Crypto and market-closed states: element is cleared (empty string)

## Setup

Add `TWELVE_DATA_API_KEY=your_key` to `.env.local`. If the key is absent, the proxy returns a 503 and the existing Yahoo Finance fallback takes over automatically.

Closes #21

---
Generated with [Claude Code](https://claude.ai/code)