### PR TITLE
fix: disable futures/FX in asset selector with Soon badges

### DIFF
--- a/app.js
+++ b/app.js
@@ -2059,6 +2059,21 @@ function onCapitalChange() {
 // ASSET SELECTOR
 // ============================================================
 
+// Canonical display order for asset groups in the selector.
+const SELECTOR_GROUP_ORDER = [
+  'Crypto',
+  'Futures — Indices',
+  'Futures — Commodities',
+  'FX Pairs',
+];
+
+// Returns true for assets that are visible but not yet available for trading.
+// To re-enable futures/FX: remove this function and its call sites.
+function isAssetComingSoon(assetKey) {
+  const asset = ASSETS[assetKey];
+  return asset ? asset.market !== 'crypto' : false;
+}
+
 function buildAssetSelector() {
   const container = el('asset-selector-dropdown');
   if (!container) return;
@@ -2071,7 +2086,14 @@ function buildAssetSelector() {
   }
 
   container.innerHTML = '';
-  for (const [category, assets] of Object.entries(groups)) {
+  // Render groups in canonical order; fall back to any extra categories at the end.
+  const orderedCategories = [
+    ...SELECTOR_GROUP_ORDER.filter(c => groups[c]),
+    ...Object.keys(groups).filter(c => !SELECTOR_GROUP_ORDER.includes(c)),
+  ];
+
+  orderedCategories.forEach(category => {
+    const assets = groups[category];
     const groupEl = document.createElement('div');
     groupEl.className = 'asset-group';
 
@@ -2081,9 +2103,15 @@ function buildAssetSelector() {
     groupEl.appendChild(labelEl);
 
     assets.forEach(a => {
+      const comingSoon = isAssetComingSoon(a.key);
       const item = document.createElement('button');
       item.className = 'asset-item' + (a.key === state.currentAsset ? ' selected' : '');
-      if (!a.bitfinex && !a.binance && !a.tradingview) item.classList.add('no-data');
+
+      if (comingSoon) {
+        item.classList.add('soon');
+        item.disabled = true;
+        item.setAttribute('aria-disabled', 'true');
+      }
 
       const open = isMarketOpen(a.key);
       const dot  = a.market === 'crypto' ? '🟢' : (open ? '🟢' : '🔴');
@@ -2091,17 +2119,20 @@ function buildAssetSelector() {
       item.innerHTML = `
         <span class="asset-item-symbol">${a.key}</span>
         <span class="asset-item-name">${a.name}</span>
-        <span class="asset-item-status">${dot}</span>
+        ${comingSoon ? '<span class="soon-badge">Soon</span>' : `<span class="asset-item-status">${dot}</span>`}
       `;
-      item.addEventListener('click', () => {
-        switchAsset(a.key);
-        toggleAssetSelector(false);
-      });
+
+      if (!comingSoon) {
+        item.addEventListener('click', () => {
+          switchAsset(a.key);
+          toggleAssetSelector(false);
+        });
+      }
       groupEl.appendChild(item);
     });
 
     container.appendChild(groupEl);
-  }
+  });
 }
 
 function toggleAssetSelector(forceState) {
@@ -2134,6 +2165,7 @@ function closeAssetSelectorOnOutside(e) {
 
 function switchAsset(key) {
   if (!ASSETS[key]) return;
+  if (isAssetComingSoon(key)) return; // disabled until futures/FX go live
   state.currentAsset = key;
   state.lastCandles  = null;
   state.lastResult   = null;
@@ -2215,6 +2247,10 @@ function bindEvents() {
 }
 
 function init() {
+  // Safety: if the default/persisted asset is disabled, fall back to BTC/USD.
+  if (isAssetComingSoon(state.currentAsset)) {
+    state.currentAsset = 'BTC/USD';
+  }
   bindEvents();
   initFooter();
   buildAssetSelector();

--- a/style.css
+++ b/style.css
@@ -378,6 +378,34 @@ html, body {
   opacity: 0.5;
 }
 
+/* Coming-soon: futures & FX disabled until fully supported */
+.asset-item.soon {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.asset-item.soon:hover {
+  background: transparent;
+}
+.asset-item.soon .asset-item-symbol,
+.asset-item.soon .asset-item-name {
+  color: var(--text-muted);
+}
+
+.soon-badge {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--bg-card-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 5px;
+  line-height: 1;
+}
+
 .asset-item-symbol {
   font-size: 12px;
   font-weight: 700;


### PR DESCRIPTION
## Summary

- Reorders the asset selector: **Crypto first**, then Futures — Indices, Futures — Commodities, FX Pairs
- All non-crypto assets (futures + FX) are **visible but disabled** — greyed out, non-interactive, `disabled` attribute set, with a subtle **"Soon" badge** replacing the market status dot
- Guards added in `switchAsset()` and `init()` to prevent any path from activating a disabled asset
- Futures/FX definitions remain untouched in the codebase

## Files changed

| File | Change |
|------|--------|
| `app.js` | Added `SELECTOR_GROUP_ORDER` constant, `isAssetComingSoon()` helper, rewrote `buildAssetSelector()` with disabled-state logic, guarded `switchAsset()` and `init()` |
| `style.css` | Added `.asset-item.soon` (cursor: not-allowed, opacity: 0.45, pointer-events: none, no hover) and `.soon-badge` (subtle pill matching existing design) |

## How the disabled state is enforced

1. **`isAssetComingSoon(key)`** — returns `true` for any asset with `market !== 'crypto'`
2. **`buildAssetSelector()`** — disabled items get `item.disabled = true`, `aria-disabled="true"`, `.soon` CSS class, no click listener, and a "Soon" badge instead of the market dot
3. **`switchAsset()`** — early return if `isAssetComingSoon(key)` (blocks keyboard nav, direct calls, etc.)
4. **`init()`** — resets `state.currentAsset` to `'BTC/USD'` if it resolves to a coming-soon asset on startup

## How to revert when futures/FX are ready

Remove `isAssetComingSoon()` and its calls in `buildAssetSelector()`, `switchAsset()`, and `init()`. Remove `SELECTOR_GROUP_ORDER` if you want to revert the ordering too (or keep it — the order is better). Remove `.soon` and `.soon-badge` CSS.

Closes #21