### PR TITLE
feat: Add AI Agent tab powered by Claude

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
 VITE_FIREBASE_API_KEY=your_api_key_here
 VITE_FIREBASE_AUTH_DOMAIN=yourproject.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=yourproject

--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,381 @@
+// ============================================================
+// SqFlow — AI Agent Tab  (Issue #123)
+// Powered by Claude via server-side /api/claude proxy.
+// Reads window.sqflowState written by app.js after each renderDashboard().
+// ============================================================
+
+(function () {
+  'use strict';
+
+  var SYSTEM_PROMPT = [
+    'You are an expert swing trading analyst specializing in the Jaime Merino',
+    '(TradingLatino) strategy. You will receive live technical indicator data',
+    'from a trading dashboard called SqFlow and must produce a structured',
+    'analysis following the methodology below.',
+    '',
+    '## METHODOLOGY',
+    '',
+    '- Trend defined by EMA55 and EMA200 alignment',
+    '- Entry on pullback to EMA55 zone (within 3%)',
+    '- Confirmation via ADX > 23 with rising slope',
+    '- Momentum filter: RSI(14) not overextended (< 70 for longs, > 30 for shorts)',
+    '- Volatility catalyst: TTM Squeeze fired or positive momentum histogram',
+    '- Volume anchor: price within 2.5% of Volume Point of Control (VOL POC)',
+    '- Stop Loss: fixed 7% below entry',
+    '- Take Profit: fixed 21% above entry (1:3 R:R)',
+    '- Partial scale-out at +14% (1:2 R:R)',
+    '- Minimum acceptable R:R: 2:1',
+    '',
+    '## OUTPUT FORMAT',
+    '',
+    'Always respond with this exact structure:',
+    '',
+    '---',
+    '### VERDICT: [LONG \u2705 / SHORT \u2705 / WAIT \u23f3 / DISCARD \u274c]',
+    '### SCORE: [X/10]',
+    '',
+    '**Trend Context**',
+    '[2-3 sentences on EMA alignment and macro bias]',
+    '',
+    '**Pullback Quality**',
+    '[Is price in the ideal zone? Is the pullback orderly?]',
+    '',
+    '**Confirmation**',
+    '[ADX, RSI, Squeeze, VOL POC status]',
+    '',
+    '**Levels**',
+    '- Entry: [price or "current market"]',
+    '- Stop Loss: [price] (\u22127%)',
+    '- Target 1: [price] (+14% / 1:2 R:R)',
+    '- Target 2: [price] (+21% / 1:3 R:R)',
+    '',
+    '**Positive Factors**',
+    '- [bullet list]',
+    '',
+    '**Risk Factors**',
+    '- [bullet list]',
+    '',
+    '**Summary**',
+    '[3-4 sentence synthesis. Be direct. If the setup is weak, say so.]',
+    '---',
+    '',
+    'Do not add disclaimers or financial advice warnings.',
+    'Keep the tone analytical, direct, and professional.',
+  ].join('\n');
+
+  function fmtNum(n) {
+    if (n === null || n === undefined || isNaN(n)) return 'N/A';
+    return Number(n).toFixed(2);
+  }
+
+  function buildUserContext(s) {
+    var ind = s.indicators || {};
+    var tp  = s.tradeParams || {};
+    var sqz = ind.squeeze || {};
+    var conditions = (s.conditions || []).map(function (c, i) {
+      return 'C' + (i + 1) + ': ' + c.label + ' — ' + (c.met ? 'MET' : 'NOT MET') + (c.detail ? ' | ' + c.detail : '');
+    }).join('\n');
+
+    return [
+      'ASSET: ' + s.asset + ' (' + s.assetName + ')',
+      'TIMEFRAME: ' + s.timeframe,
+      'CURRENT PRICE: ' + fmtNum(s.price),
+      'MARKET OPEN: ' + (s.marketOpen ? 'Yes' : 'No'),
+      'SIGNAL: ' + s.signal,
+      'DIRECTION BIAS: ' + s.direction,
+      'CONDITIONS MET: ' + s.metCount + '/5',
+      '',
+      '--- INDICATORS ---',
+      'EMA10:  ' + fmtNum(ind.ema10),
+      'EMA55:  ' + fmtNum(ind.ema55),
+      'EMA200: ' + fmtNum(ind.ema200),
+      'RSI(14): ' + fmtNum(ind.rsi),
+      'ADX(14): ' + fmtNum(ind.adx),
+      'BB Upper: ' + fmtNum(ind.bbUpper),
+      'BB Lower: ' + fmtNum(ind.bbLower),
+      'Squeeze ON: ' + (sqz.sqzOn ? 'Yes' : 'No'),
+      'Squeeze Just Fired: ' + (sqz.sqzJustFired ? 'Yes' : 'No'),
+      'Squeeze Histogram: ' + fmtNum(sqz.histogram),
+      'VOL POC: ' + fmtNum(ind.poc),
+      '',
+      '--- TRADE PARAMETERS ---',
+      'Entry: ' + fmtNum(tp.entry),
+      'Stop Loss: ' + fmtNum(tp.stopLoss),
+      'Take Profit: ' + fmtNum(tp.takeProfit),
+      'Leverage: ' + (tp.leverage || 0) + 'x',
+      '',
+      '--- CONDITIONS ---',
+      conditions,
+      '',
+      'Please provide your full Jaime Merino strategy analysis for this setup.',
+    ].join('\n');
+  }
+
+  // ── DOM helpers ────────────────────────────────────────────
+
+  function escHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function renderSkeleton(panel) {
+    panel.innerHTML =
+      '<div class="agent-loading" role="status" aria-live="polite">' +
+        '<div class="agent-skeleton agent-skeleton-title"></div>' +
+        '<div class="agent-skeleton agent-skeleton-line"></div>' +
+        '<div class="agent-skeleton agent-skeleton-line short"></div>' +
+        '<div class="agent-skeleton agent-skeleton-line"></div>' +
+        '<div class="agent-skeleton agent-skeleton-line short"></div>' +
+      '</div>';
+  }
+
+  function renderError(panel, msg) {
+    panel.innerHTML =
+      '<div class="agent-error" role="alert">' +
+        '<div class="agent-error-icon" aria-hidden="true">&#9888;</div>' +
+        '<div class="agent-error-title">Analysis Unavailable</div>' +
+        '<div class="agent-error-msg">' + escHtml(msg) + '</div>' +
+      '</div>' +
+      renderChatHtml();
+    bindChat(panel);
+  }
+
+  function markdownToHtml(text) {
+    // Basic markdown: headers, bold, bullets, horizontal rules, newlines
+    return text
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/^---$/gm, '<hr>')
+      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+      .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/^- (.+)$/gm, '<li>$1</li>')
+      .replace(/(<li>.*<\/li>\n?)+/g, function(m) { return '<ul>' + m + '</ul>'; })
+      .replace(/\n{2,}/g, '</p><p>')
+      .replace(/\n/g, '<br>');
+  }
+
+  function renderChatHtml() {
+    return '<div class="agent-chat-wrap">' +
+      '<div class="agent-chat-history" id="agent-chat-history" aria-live="polite" aria-label="Chat history"></div>' +
+      '<div class="agent-chat-input-row">' +
+        '<input type="text" class="agent-chat-input" id="agent-chat-input" ' +
+          'placeholder="Ask a follow-up question about this setup\u2026" ' +
+          'aria-label="Follow-up question">' +
+        '<button class="agent-chat-send" id="agent-chat-send" aria-label="Send question">Send</button>' +
+      '</div>' +
+    '</div>';
+  }
+
+  function renderAnalysis(panel, text, s) {
+    var header =
+      '<div class="agent-header">' +
+        '<span class="agent-asset-badge">' + escHtml(s.asset) + ' &middot; ' + escHtml(s.timeframe) + '</span>' +
+        '<button class="agent-rerun-btn" id="agent-rerun-btn" aria-label="Re-run analysis">' +
+          '&#8635; Re-run Analysis' +
+        '</button>' +
+      '</div>';
+
+    var analysisHtml =
+      '<div class="agent-analysis" role="region" aria-label="AI analysis">' +
+        '<div class="agent-analysis-body">' + markdownToHtml(text) + '</div>' +
+      '</div>';
+
+    panel.innerHTML = header + analysisHtml + renderChatHtml();
+
+    var rerunBtn = document.getElementById('agent-rerun-btn');
+    if (rerunBtn) {
+      rerunBtn.addEventListener('click', function () {
+        runAnalysis(panel, window.sqflowState);
+      });
+    }
+
+    bindChat(panel);
+  }
+
+  // ── Chat ───────────────────────────────────────────────────
+
+  var chatMessages = [];
+
+  function bindChat(panel) {
+    var input  = document.getElementById('agent-chat-input');
+    var sendBtn = document.getElementById('agent-chat-send');
+    if (!input || !sendBtn) return;
+
+    function send() {
+      var q = input.value.trim();
+      if (!q) return;
+      input.value = '';
+      sendFollowUp(panel, q);
+    }
+
+    sendBtn.addEventListener('click', send);
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') send();
+    });
+  }
+
+  function appendChatMessage(role, text) {
+    var history = document.getElementById('agent-chat-history');
+    if (!history) return;
+    var div = document.createElement('div');
+    div.className = 'agent-chat-msg agent-chat-msg-' + role;
+    div.innerHTML = role === 'assistant'
+      ? markdownToHtml(text)
+      : escHtml(text);
+    history.appendChild(div);
+    history.scrollTop = history.scrollHeight;
+  }
+
+  function sendFollowUp(panel, question) {
+    chatMessages.push({ role: 'user', content: question });
+    appendChatMessage('user', question);
+
+    var sendBtn = document.getElementById('agent-chat-send');
+    var input   = document.getElementById('agent-chat-input');
+    if (sendBtn) { sendBtn.disabled = true; sendBtn.textContent = '\u23f3'; }
+    if (input) input.disabled = true;
+
+    var messages = chatMessages.slice();
+
+    fetch('/api/claude', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1500,
+        system: SYSTEM_PROMPT,
+        messages: messages,
+      }),
+    })
+    .then(function (res) { return res.json(); })
+    .then(function (data) {
+      if (data.error) throw new Error(data.error);
+      var reply = data.content && data.content[0] && data.content[0].text
+        ? data.content[0].text
+        : JSON.stringify(data);
+      chatMessages.push({ role: 'assistant', content: reply });
+      appendChatMessage('assistant', reply);
+    })
+    .catch(function (err) {
+      appendChatMessage('assistant', 'Error: ' + err.message);
+    })
+    .finally(function () {
+      if (sendBtn) { sendBtn.disabled = false; sendBtn.textContent = 'Send'; }
+      if (input) input.disabled = false;
+    });
+  }
+
+  // ── API call ───────────────────────────────────────────────
+
+  function runAnalysis(panel, s) {
+    if (!s) {
+      renderError(panel, 'No market data available yet. Please wait for the dashboard to load and try again.');
+      return;
+    }
+
+    chatMessages = [];
+
+    var userContent = buildUserContext(s);
+    renderSkeleton(panel);
+
+    // Seed chat history with this analysis request
+    chatMessages.push({ role: 'user', content: userContent });
+
+    fetch('/api/claude', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1500,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userContent }],
+      }),
+    })
+    .then(function (res) { return res.json(); })
+    .then(function (data) {
+      if (data.error) throw new Error(data.error);
+      var text = data.content && data.content[0] && data.content[0].text
+        ? data.content[0].text
+        : JSON.stringify(data);
+      chatMessages.push({ role: 'assistant', content: text });
+      renderAnalysis(panel, text, s);
+    })
+    .catch(function (err) {
+      renderError(panel, err.message);
+    });
+  }
+
+  // ── State-updated banner ───────────────────────────────────
+
+  var _pendingStateUpdate = false;
+
+  window.addEventListener('sqflow:stateUpdated', function () {
+    // Only show prompt if agent tab is not currently active
+    var activeTab = document.querySelector('.tab-nav-btn.active');
+    if (activeTab && activeTab.dataset && activeTab.dataset.tab === 'agent') return;
+    _pendingStateUpdate = true;
+  });
+
+  function maybeShowUpdateBanner(panel) {
+    if (!_pendingStateUpdate) return;
+    _pendingStateUpdate = false;
+    var existing = panel.querySelector('.agent-update-banner');
+    if (existing) existing.remove();
+
+    var banner = document.createElement('div');
+    banner.className = 'agent-update-banner';
+    banner.setAttribute('role', 'status');
+    banner.innerHTML =
+      'State updated \u2014 <button class="agent-update-banner-btn" id="agent-rerun-banner-btn">re-run analysis?</button>' +
+      '<button class="agent-update-banner-close" aria-label="Dismiss">&times;</button>';
+    panel.insertBefore(banner, panel.firstChild);
+
+    var rerunBtn = banner.querySelector('#agent-rerun-banner-btn');
+    if (rerunBtn) {
+      rerunBtn.addEventListener('click', function () {
+        banner.remove();
+        runAnalysis(panel, window.sqflowState);
+      });
+    }
+    var closeBtn = banner.querySelector('.agent-update-banner-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () { banner.remove(); });
+    }
+  }
+
+  // ── Init ───────────────────────────────────────────────────
+
+  function initAgentTab() {
+    var panel = document.getElementById('panel-agent');
+    if (!panel) return;
+
+    // Show placeholder on first load
+    panel.innerHTML =
+      '<div class="agent-placeholder">' +
+        '<div class="agent-placeholder-icon" aria-hidden="true">&#129302;</div>' +
+        '<div class="agent-placeholder-title">AI Agent</div>' +
+        '<div class="agent-placeholder-desc">Switch to this tab after loading dashboard data to get a full Jaime Merino strategy analysis for the current asset.</div>' +
+      '</div>';
+
+    window.addEventListener('sqflow:agentTabActivated', function () {
+      maybeShowUpdateBanner(panel);
+      // Only auto-run if no analysis is showing yet
+      var hasAnalysis = panel.querySelector('.agent-analysis');
+      if (!hasAnalysis) {
+        runAnalysis(panel, window.sqflowState);
+      }
+    });
+  }
+
+  // Run after DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAgentTab);
+  } else {
+    initAgentTab();
+  }
+
+}());

--- a/app.js
+++ b/app.js
@@ -1787,6 +1787,40 @@ function updateUI(r, capital) {
 
   el('last-update').textContent = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     + (USER_TZ_ABBR ? '\u00a0' + USER_TZ_ABBR : '');
+
+  // Expose current computed state for agent.js
+  window.sqflowState = {
+    asset:      state.currentAsset,
+    assetName:  ASSETS[state.currentAsset] ? ASSETS[state.currentAsset].name : state.currentAsset,
+    timeframe:  state.currentTimeframe,
+    price:      r.currentPrice,
+    signal:     r.signal,
+    metCount:   r.metCount,
+    direction:  r.direction,
+    conditions: r.conditions,
+    indicators: {
+      ema10:   r.ema10,
+      ema55:   r.ema55,
+      ema200:  r.ema200,
+      rsi:     r.rsi,
+      adx:     r.adx,
+      bbUpper: r.bb ? r.bb.upper : null,
+      bbLower: r.bb ? r.bb.lower : null,
+      squeeze: { sqzOn: r.sqz ? r.sqz.sqzOn : false, sqzJustFired: r.sqzJustFired, histogram: r.sqz ? r.sqz.val : 0 },
+      poc:     r.poc,
+    },
+    tradeParams: {
+      entry:      r.currentPrice,
+      stopLoss:   r.stopLoss,
+      takeProfit: r.takeProfit,
+      leverage:   r.leverage,
+    },
+    marketOpen: isMarketOpen(state.currentAsset),
+    timestamp:  Date.now(),
+  };
+
+  // Notify agent panel that state was updated (e.g. after a Refresh Now)
+  window.dispatchEvent(new CustomEvent('sqflow:stateUpdated'));
 }
 
 // ============================================================
@@ -1891,9 +1925,14 @@ function switchTab(tab) {
   el('panel-dashboard').style.display    = tab === 'dashboard'    ? '' : 'none';
   el('panel-activetrades').style.display = tab === 'activetrades' ? '' : 'none';
   el('panel-history').style.display      = tab === 'history'      ? '' : 'none';
+  el('panel-agent').style.display        = tab === 'agent'        ? '' : 'none';
   el('panel-strategy').style.display     = tab === 'strategy'     ? '' : 'none';
   el('panel-bugreport').style.display    = tab === 'bugreport'    ? '' : 'none';
   el('panel-about').style.display        = tab === 'about'        ? '' : 'none';
+
+  if (tab === 'agent' && window.sqflowState) {
+    window.dispatchEvent(new CustomEvent('sqflow:agentTabActivated'));
+  }
 
   // Hide asset selector on non-dashboard tabs — prevents confusing pair-switch
   // flicker in Active Trades and History where the selected pair is irrelevant.

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
         History
         <span class="tab-badge" id="history-tab-badge" style="display:none" aria-label="Trade count"></span>
       </button>
+      <button class="tab-nav-btn" data-tab="agent" aria-selected="false" role="tab">AI Agent</button>
       <button class="tab-nav-btn" data-tab="strategy" aria-selected="false" role="tab">Strategy</button>
       <button class="tab-nav-btn" data-tab="bugreport" aria-selected="false" role="tab">Report a Bug</button>
       <button class="tab-nav-btn" data-tab="about" aria-selected="false" role="tab">About</button>
@@ -260,6 +261,9 @@
         <div class="history-list" id="history-list" role="list" aria-label="Closed trades"></div>
       </section>
     </div>
+
+    <!-- AI AGENT PANEL -->
+    <div id="panel-agent" style="display:none" role="tabpanel" aria-label="AI Agent"></div>
 
     <!-- STRATEGY PANEL -->
     <div id="panel-strategy" style="display:none" role="tabpanel" aria-label="Strategy guide">
@@ -1004,5 +1008,6 @@
   <!-- Auth module must load before app.js so Auth global is available -->
   <script src="auth.js?v=2"></script>
   <script src="app.js?v=14"></script>
+  <script src="agent.js?v=1"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -57,7 +57,7 @@ function setCORSHeaders(req, res) {
     // Vary: Origin tells caches to store separate responses per origin.
     res.setHeader('Vary', 'Origin');
   }
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 }
 
@@ -172,6 +172,28 @@ function httpsGet(reqUrl) {
     };
 
     get(reqUrl, 0);
+  });
+}
+
+// ── HTTPS POST helper ────────────────────────────────────────
+function httpsPOST(reqUrl, headers, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(reqUrl);
+    const options = {
+      hostname: url.hostname,
+      path: url.pathname,
+      method: 'POST',
+      headers: { ...headers, 'Content-Length': Buffer.byteLength(body) },
+    };
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
   });
 }
 
@@ -381,6 +403,35 @@ const server = http.createServer((req, res) => {
   // Route: /api/market-data (Yahoo Finance proxy)
   if (pathname === '/api/market-data' && req.method === 'GET') {
     handleMarketData(query, res);
+    return;
+  }
+
+  // Route: /api/claude — Anthropic API proxy
+  if (pathname === '/api/claude' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const payload = JSON.parse(body);
+        const apiKey = process.env.ANTHROPIC_API_KEY;
+        if (!apiKey) {
+          res.writeHead(503, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured on server.' }));
+          return;
+        }
+        const anthropicRes = await httpsPOST('https://api.anthropic.com/v1/messages', {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        }, JSON.stringify(payload));
+
+        res.writeHead(anthropicRes.statusCode, { 'Content-Type': 'application/json' });
+        res.end(anthropicRes.body);
+      } catch (err) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
     return;
   }
 

--- a/style.css
+++ b/style.css
@@ -3262,3 +3262,205 @@ html, body {
 .confirm-modal-confirm.danger {
   background: var(--danger);
 }
+
+/* ── AI Agent Tab ──────────────────────────────────────────── */
+#panel-agent {
+  padding: 24px 0;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.agent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.agent-asset-badge {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 4px 12px;
+  letter-spacing: 0.04em;
+}
+
+.agent-rerun-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: var(--text-sm);
+  padding: 6px 14px;
+  transition: border-color var(--transition-base), color var(--transition-base);
+}
+.agent-rerun-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Loading skeleton */
+.agent-loading { padding: 24px 0; }
+.agent-skeleton {
+  background: linear-gradient(90deg, var(--surface-raised) 25%, var(--border) 50%, var(--surface-raised) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s infinite;
+  border-radius: var(--radius-sm);
+  margin-bottom: 12px;
+}
+.agent-skeleton-title { height: 22px; width: 40%; }
+.agent-skeleton-line  { height: 14px; width: 90%; }
+.agent-skeleton-line.short { width: 65%; }
+
+@keyframes skeleton-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Error state */
+.agent-error {
+  background: var(--surface-raised);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  padding: 24px;
+  text-align: center;
+}
+.agent-error-icon { font-size: 28px; margin-bottom: 8px; color: var(--danger); }
+.agent-error-title { font-size: var(--text-lg); font-weight: 700; margin-bottom: 8px; }
+.agent-error-msg { color: var(--text-secondary); font-size: var(--text-sm); }
+
+/* Analysis output */
+.agent-analysis {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin-bottom: 20px;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+}
+.agent-analysis-body h1,
+.agent-analysis-body h2,
+.agent-analysis-body h3 {
+  color: var(--text-primary);
+  margin: 16px 0 8px;
+}
+.agent-analysis-body h3 { font-size: var(--text-base); }
+.agent-analysis-body hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+.agent-analysis-body ul { padding-left: 20px; margin: 8px 0; }
+.agent-analysis-body li { margin-bottom: 4px; }
+.agent-analysis-body strong { color: var(--text-primary); }
+.agent-analysis-body p { margin: 8px 0; }
+
+/* Placeholder */
+.agent-placeholder {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-secondary);
+}
+.agent-placeholder-icon { font-size: 42px; margin-bottom: 12px; }
+.agent-placeholder-title { font-size: var(--text-lg); font-weight: 700; color: var(--text-primary); margin-bottom: 8px; }
+.agent-placeholder-desc { font-size: var(--text-sm); max-width: 480px; margin: 0 auto; line-height: 1.6; }
+
+/* Chat */
+.agent-chat-wrap {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+.agent-chat-history {
+  max-height: 320px;
+  overflow-y: auto;
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.agent-chat-msg {
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  padding: 10px 14px;
+  max-width: 88%;
+}
+.agent-chat-msg-user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #fff;
+}
+.agent-chat-msg-assistant {
+  align-self: flex-start;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+}
+.agent-chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+.agent-chat-input {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font);
+  font-size: var(--text-sm);
+  padding: 8px 12px;
+  transition: border-color var(--transition-base);
+}
+.agent-chat-input:focus { border-color: var(--accent); outline: none; }
+.agent-chat-input::placeholder { color: var(--text-muted); }
+.agent-chat-send {
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 8px 18px;
+  transition: opacity var(--transition-base);
+}
+.agent-chat-send:hover { opacity: 0.88; }
+.agent-chat-send:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* State-updated banner */
+.agent-update-banner {
+  background: var(--surface-raised);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.agent-update-banner-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: 0;
+  text-decoration: underline;
+}
+.agent-update-banner-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  margin-left: auto;
+  padding: 0 2px;
+}


### PR DESCRIPTION
## Summary

- **`agent.js`** (new): Self-contained module exposing `initAgentTab()`. Reads `window.sqflowState` set by `app.js`, calls `POST /api/claude`, renders a full Jaime Merino strategy analysis (verdict, score, levels, positive/risk factors) with a loading skeleton, graceful error handling, and a follow-up chat input.
- **`index.html`**: Added "AI Agent" tab button between History and Strategy; added `#panel-agent` div; added `<script src="agent.js?v=1">`.
- **`app.js`**: `switchTab()` now shows/hides `panel-agent` and dispatches `sqflow:agentTabActivated`; `updateUI()` writes `window.sqflowState` after every successful render and dispatches `sqflow:stateUpdated` (triggers "State updated — re-run analysis?" banner in agent panel).
- **`server.js`**: Added `httpsPOST` helper; added `POST /api/claude` route that proxies requests to Anthropic using `ANTHROPIC_API_KEY` from env (key never sent to client); CORS updated to allow POST.
- **`style.css`**: Dark-theme styles for agent panel, shimmer skeleton, analysis output, chat UI, and state-update banner.
- **`.env.example`**: `ANTHROPIC_API_KEY` entry added.

## Test plan

- [ ] Start server: `node server.js`
- [ ] Open dashboard, let it load market data for any asset/timeframe
- [ ] Click "AI Agent" tab — skeleton appears then analysis renders with verdict, score, levels, positives, risks
- [ ] Enter a follow-up question in the chat input and verify a response appears
- [ ] Click "Refresh Now" on dashboard, then switch back to AI Agent — "State updated — re-run analysis?" banner appears
- [ ] Start server without `ANTHROPIC_API_KEY` set — agent panel shows configuration error, no crash
- [ ] Verify all other tabs (Dashboard, Active Trades, History, Strategy, Report a Bug, About) are unaffected
- [ ] Verify no API key appears in browser network requests

Closes #123

https://claude.ai/code/session_01HkUWhqxrRpDXcqx8HsfZB7